### PR TITLE
Connection introspection (rdt-toolchain-2.9)

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -105,7 +105,7 @@ namespace RTT
 
         this->addOperation("trigger", &TaskContext::trigger, this, ClientThread).doc("Trigger the update method for execution in the thread of this task.\n Only succeeds if the task isRunning() and allowed by the Activity executing this task.");
         this->addOperation("loadService", &TaskContext::loadService, this, ClientThread).doc("Loads a service known to RTT into this component.").arg("service_name","The name with which the service is registered by in the PluginLoader.");
-        this->addOperation("port_connections", &TaskContext::listPortConnections, this, ClientThread).doc("Logs a list of connections for all ports in this component.")
+        this->addOperation("showPortConnections", &TaskContext::showPortConnections, this, ClientThread).doc("Logs a list of connections for all ports in this component.")
                 .arg("depth", "Number of levels to look for: 1 will only list direct connections, more than 1 will also look at connected ports connections.");
 
         this->addAttribute("TriggerOnStart",mTriggerOnStart);
@@ -454,7 +454,7 @@ namespace RTT
         }
     }
 
-    void TaskContext::listPortConnections(int depth) const
+    void TaskContext::showPortConnections(int depth) const
     {
         if (depth < 1) {depth = 1;}
 

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -47,6 +47,7 @@
 #include <boost/bind.hpp>
 #include <boost/mem_fn.hpp>
 
+#include "internal/ConnectionIntrospector.hpp"
 #include "internal/DataSource.hpp"
 #include "internal/mystd.hpp"
 #include "internal/MWSRQueue.hpp"
@@ -104,6 +105,8 @@ namespace RTT
 
         this->addOperation("trigger", &TaskContext::trigger, this, ClientThread).doc("Trigger the update method for execution in the thread of this task.\n Only succeeds if the task isRunning() and allowed by the Activity executing this task.");
         this->addOperation("loadService", &TaskContext::loadService, this, ClientThread).doc("Loads a service known to RTT into this component.").arg("service_name","The name with which the service is registered by in the PluginLoader.");
+        this->addOperation("port_connections", &TaskContext::listPortConnections, this, ClientThread).doc("Logs a list of connections for all ports in this component.")
+                .arg("depth", "Number of levels to look for: 1 will only list direct connections, more than 1 will also look at connected ports connections.");
 
         this->addAttribute("TriggerOnStart",mTriggerOnStart);
         this->addAttribute("CycleCounter",mCycleCounter);
@@ -449,6 +452,15 @@ namespace RTT
         if (it != user_callbacks.end() ) {
             user_callbacks.erase(it);
         }
+    }
+
+    void TaskContext::listPortConnections(int depth) const
+    {
+        if (depth < 1) {depth = 1;}
+
+        ConnectionIntrospector ci(this);
+        ci.createGraph(depth);
+        std::cout << "\n" << ci << std::endl;
     }
 }
 

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -697,7 +697,7 @@ namespace RTT
          * @param depth Levels to explore: 1 (or less) will only explore direct
          *              connections.
          */
-        void listPortConnections(int depth) const;
+        void showPortConnections(int depth) const;
     };
 
     /**

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -691,6 +691,13 @@ namespace RTT
          * setActivity. By default, a extras::SequentialActivity is assigned.
          */
         base::ActivityInterface::shared_ptr our_act;
+
+        /**
+         * Lists all connections this component' ports have, up to depth levels.
+         * @param depth Levels to explore: 1 (or less) will only explore direct
+         *              connections.
+         */
+        void listPortConnections(int depth) const;
     };
 
     /**

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -698,6 +698,16 @@ namespace RTT
          *              connections.
          */
         void showPortConnections(int depth) const;
+
+        /**
+         * Creates a graph with all connections this component' ports have, up
+         * to @p depth levels, and writes it to file @p filename.
+         * @param depth Levels to explore: 1 (or less) will only explore direct
+         *              connections.
+         * @param filename Name of the file to write the connections graph to.
+         */
+        void printPortConnectionsGraph(int depth,
+                                       const std::string& filename) const;
     };
 
     /**

--- a/rtt/base/ChannelElementBase.hpp
+++ b/rtt/base/ChannelElementBase.hpp
@@ -265,6 +265,44 @@ namespace RTT { namespace base {
             (void) addInput(input);
         }
 
+        /**
+         * This function may be used to identify,
+         * if the current element uses a network
+         * transport, to send the data to the next
+         * Element in the logical chain.
+         *
+         * @return true if a network transport is used.
+         * */
+        virtual bool isRemoteElement() const;
+
+        /**
+         * This function returns the URI of the
+         * next channel element in the logical
+         * chain. The URI must be unique.
+         * E.g: In the local case output->getLocalURI()
+         * In the remote case the URI of the remote
+         * channel element.
+         *
+         * @return URI of the next element.
+         * */
+        virtual std::string getRemoteURI() const;
+
+        /**
+         * This function return the URI of this
+         * element. The URI must be unique.
+         * @return URI of this element.
+         * */
+        virtual std::string getLocalURI() const;
+
+        /**
+         * Returns the class name of this
+         * element. This is primary useful
+         * for special case handling in the
+         * connection tracking.
+         * @return The name of the class of the ChannelElement
+         * */
+        virtual std::string getElementName() const;
+
     protected:
         friend class MultipleInputsChannelElementBase;
         friend class MultipleOutputsChannelElementBase;

--- a/rtt/base/ChannelInterface.cpp
+++ b/rtt/base/ChannelInterface.cpp
@@ -40,6 +40,7 @@
 #include "../os/Atomic.hpp"
 #include "../os/CAS.hpp"
 #include "../os/MutexLock.hpp"
+#include <boost/lexical_cast.hpp>
 
 using namespace RTT;
 using namespace RTT::detail;
@@ -459,6 +460,26 @@ bool MultipleInputsMultipleOutputsChannelElementBase::disconnect(ChannelElementB
         // disconnect all inputs
         return MultipleInputsChannelElementBase::disconnect(0, forward);
     }
+}
+
+bool ChannelElementBase::isRemoteElement() const {
+    return false;
+}
+
+std::string ChannelElementBase::getRemoteURI() const {
+    if(!output)
+    {
+        return std::string();
+    }
+    return output->getLocalURI();
+}
+
+std::string ChannelElementBase::getLocalURI() const {
+    return std::string(boost::lexical_cast<std::string>(this));
+}
+
+std::string ChannelElementBase::getElementName() const {
+    return std::string("ChannelElementBase");
 }
 
 void ChannelElementBase::ref()

--- a/rtt/base/PortInterface.cpp
+++ b/rtt/base/PortInterface.cpp
@@ -88,9 +88,8 @@ Service* PortInterface::createPortObject()
     typedef void (PortInterface::*disconnect_all)();
     to->addSynchronousOperation("disconnect", static_cast<disconnect_all>(&PortInterface::disconnect), this).doc("Disconnects this port from any connection it is part of.");
 
-    typedef void (PortInterface::*PortConnections)(int) const;
-    PortConnections port_connections = &PortInterface::listPortConnections;
-    to->addSynchronousOperation("port_connections", port_connections, this).doc(
+    to->addSynchronousOperation("showPortConnections",
+        &PortInterface::showPortConnections, this).doc(
             "Logs a list of connections for this port.").arg(
                 "depth", "Number of levels to look for: 1 will only list direct"
                 " connections, more than 1 will also look at connected ports "
@@ -120,7 +119,7 @@ internal::SharedConnectionBase::shared_ptr PortInterface::getSharedConnection() 
     return cmanager.getSharedConnection();
 }
 
-void PortInterface::listPortConnections(int depth) const
+void PortInterface::showPortConnections(int depth) const
 {
     if (depth < 1) {depth = 1;}
 

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -246,6 +246,16 @@ namespace RTT
          *              connections.
          */
         void showPortConnections(int depth) const;
+
+        /**
+         * Creates a graph with all connections this port has, up to @p depth
+         * levels, and writes it to file @p filename.
+         * @param depth Levels to explore: 1 (or less) will only explore direct
+         *              connections.
+         * @param filename Name of the file to write the connections graph to.
+         */
+        void printPortConnectionsGraph(int depth,
+                                       const std::string& filename) const;
     };
 
 }}

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -238,6 +238,14 @@ namespace RTT
          * Returns a pointer to the shared connection element this port may be connected to.
          */
         virtual internal::SharedConnectionBase::shared_ptr getSharedConnection() const;
+
+    private:
+        /**
+         * @brief Lists all connections this port has, up to depth levels.
+         * @param depth Levels to explore: 1 (or less) will only explore direct
+         *              connections.
+         */
+        void listPortConnections(int depth) const;
     };
 
 }}

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -245,7 +245,7 @@ namespace RTT
          * @param depth Levels to explore: 1 (or less) will only explore direct
          *              connections.
          */
-        void listPortConnections(int depth) const;
+        void showPortConnections(int depth) const;
     };
 
 }}

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -216,10 +216,16 @@ namespace RTT
          * in order to allow connection introspection.
          * @return null if no such manager is available, or the manager
          * otherwise.
-         * @see ConnectionManager::getChannels() for a list of all
+         * @see ConnectionManager::getConnections() for a list of all
          * connections of this port.
          */
         virtual internal::ConnectionManager* getManager() { return &cmanager; }
+
+        /**
+         * Const variant of getManager().
+         * @copydoc getManager()
+         */
+        virtual const internal::ConnectionManager* getManager() const { return &cmanager; }
 
         /**
          * Returns the input or output endpoint of this port (if any).

--- a/rtt/internal/ChannelBufferElement.hpp
+++ b/rtt/internal/ChannelBufferElement.hpp
@@ -139,6 +139,11 @@ namespace RTT { namespace internal {
         {
             return &policy;
         }
+
+        virtual std::string getElementName() const 
+        {
+            return "ChannelBufferElement";
+        }
     };
 }}
 

--- a/rtt/internal/ChannelDataElement.hpp
+++ b/rtt/internal/ChannelDataElement.hpp
@@ -104,6 +104,11 @@ namespace RTT { namespace internal {
         {
             return &policy;
         }
+
+        virtual std::string getElementName() const
+        {
+            return "ChannelDataElement";
+        };
     };
 }}
 

--- a/rtt/internal/ConnFactory.cpp
+++ b/rtt/internal/ConnFactory.cpp
@@ -58,6 +58,10 @@ ConnID* LocalConnID::clone() const {
     return new LocalConnID(this->ptr);
 }
 
+std::string LocalConnID::typeString() const {
+    return "LocalConnID";
+}
+
 bool StreamConnID::isSameID(ConnID const& id) const
 {
     StreamConnID const* real_id = dynamic_cast<StreamConnID const*>(&id);
@@ -68,6 +72,14 @@ bool StreamConnID::isSameID(ConnID const& id) const
 
 ConnID* StreamConnID::clone() const {
     return new StreamConnID(this->name_id);
+}
+
+std::string StreamConnID::typeString() const {
+    return "StreamConnID";
+}
+
+std::string StreamConnID::portName() const {
+    return this->name_id;
 }
 
 base::ChannelElementBase::shared_ptr RTT::internal::ConnFactory::buildRemoteChannelOutput(base::OutputPortInterface& output_port, base::InputPortInterface& input_port, const ConnPolicy& policy)

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -70,6 +70,7 @@ namespace RTT
             : ptr(obj) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
+        virtual std::string typeString() const;
     };
 
     /**
@@ -82,6 +83,8 @@ namespace RTT
             : name_id(name) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
+        virtual std::string typeString() const;
+        virtual std::string portName() const;
     };
 
 

--- a/rtt/internal/ConnID.cpp
+++ b/rtt/internal/ConnID.cpp
@@ -47,6 +47,10 @@
 
 using namespace RTT::internal;
 
+std::string ConnID::portName() const {
+    return "";
+}
+
 SimpleConnID::SimpleConnID(const ConnID* orig ) : cid( orig == 0 ? this : orig) {}
 bool SimpleConnID::isSameID(ConnID const& id) const {
     SimpleConnID const* real_id = dynamic_cast<SimpleConnID const*>(&id);
@@ -56,4 +60,8 @@ bool SimpleConnID::isSameID(ConnID const& id) const {
 }
 ConnID* SimpleConnID::clone() const {
     return new SimpleConnID( this->cid );
+}
+
+std::string SimpleConnID::typeString() const {
+    return "SimpleConnID";
 }

--- a/rtt/internal/ConnID.hpp
+++ b/rtt/internal/ConnID.hpp
@@ -47,6 +47,7 @@
 #define ORO_CONNID_HPP_
 
 #include "../rtt-config.h"
+#include <string>
 
 namespace RTT
 {
@@ -61,6 +62,8 @@ namespace RTT
             virtual bool isSameID(ConnID const& id) const = 0;
             virtual ConnID* clone() const = 0;
             virtual ~ConnID() {}
+            virtual std::string typeString() const = 0;
+            virtual std::string portName() const;
         };
 
         /**
@@ -73,6 +76,7 @@ namespace RTT
             SimpleConnID(const ConnID* orig = 0);
             virtual bool isSameID(ConnID const& id) const;
             virtual ConnID* clone() const;
+            virtual std::string typeString() const;
         };
     }
 }

--- a/rtt/internal/ConnInputEndPoint.hpp
+++ b/rtt/internal/ConnInputEndPoint.hpp
@@ -114,6 +114,11 @@ namespace RTT
                 return this;
             }
         }
+
+        std::string getElementName() const {
+            return std::string("ConnInputEndpoint");
+        }
+
     };
 
 }}

--- a/rtt/internal/ConnOutputEndPoint.hpp
+++ b/rtt/internal/ConnOutputEndPoint.hpp
@@ -184,6 +184,11 @@ namespace RTT
                 return this;
             }
         }
+        
+        std::string getElementName() const {
+            return std::string("ConnOutputEndpoint");
+        }
+        
     };
 
 }}

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -139,10 +139,25 @@ namespace internal {
                << " COMPONENT\n";
         } else if (this->depth == 0) {
             // For depth 0, only log the port.
+            std::string connection_summary;
+            const int connection_nr = this->sub_connections.size();
+            switch (connection_nr) {
+            case 0:
+                connection_summary = "No";
+                break;
+            case 1:
+                connection_summary = "Single";
+                break;
+            default:
+                connection_summary = "Multiple";
+                break;
+            }
             os << std::string(currIndent, ' ')
                << (this->is_forward ? " IN " : " OUT ")
                << (this->is_forward ? this->in_port
-                                         : this->out_port) << ":\n";
+                                         : this->out_port)
+               << " with " << connection_summary << " connection(s) (#"
+               << connection_nr << ")" << ":\n";
         } else if (this->depth > 0) {
             // Positive depth, log the full connection information.
             os << std::string(currIndent, ' ')

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -394,10 +394,12 @@ namespace internal {
             // Positive depth, log the full connection information.
             os << std::string(currIndent, ' ')
                << (this->is_forward ? " -> IN " : " <- OUT ")
+               << ((this->is_forward ? this->in_port
+                                         : this->out_port).is_remote ?
+                      "(remote) " : "")
                << (this->is_forward ? this->in_port
                                          : this->out_port)
-               << " : (" << this->connection_id->typeString()
-               << " = " << this->connection_policy << ")\n";
+               << " : (" << this->connection_policy << ")\n";
         }
         for (std::list< ConnectionIntrospector >::const_iterator
                 it = this->sub_connections.begin();

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -15,6 +15,7 @@ namespace internal {
                     descriptor.get<1>()->getInputEndPoint()->getPort());
         depth = curr_depth;
     }
+
     ConnectionIntrospector::ConnectionIntrospector(
             const base::PortInterface* port) {
         PortQualifier port_(port);
@@ -27,6 +28,28 @@ namespace internal {
         // opposite of the port value.
         is_forward = !port_.is_forward;
         depth = 0;
+    }
+
+    ConnectionIntrospector::ConnectionIntrospector(const TaskContext* tc) {
+        if (!tc) {
+            in_port.is_remote = true;
+            in_port.owner_name = "{EMPTY_COMPONENT}";
+            is_forward = true;
+            depth = -1;
+            return;
+        }
+        in_port.owner_name = tc->getName();
+        is_forward = true;
+        depth = -1;
+        if (tc->ports()) {
+            DataFlowInterface::PortNames port_names = tc->ports()->getPortNames();
+            for (size_t j = 0; j < port_names.size(); ++j) {
+                const std::string& port_name = port_names.at(j);
+                base::PortInterface* port_ptr = tc->getPort(port_name);
+                ConnectionIntrospector ci(port_ptr);
+                sub_connections.push_back(ci);
+            }
+        }
     }
 
     bool ConnectionIntrospector::operator==(const ConnectionIntrospector& other)
@@ -44,7 +67,15 @@ namespace internal {
 
     void ConnectionIntrospector::createGraph(int depth) {
         std::list<ConnectionIntrospector*> to_visit;
-        to_visit.push_back(this);
+        if (sub_connections.empty()) {
+            to_visit.push_back(this);
+        } else {
+            for (std::list< ConnectionIntrospector >::iterator
+                    it = this->sub_connections.begin();
+                    it != this->sub_connections.end(); ++it) {
+                to_visit.push_back(&(*it));
+            }
+        }
         std::set<ConnectionIntrospector> visited;
         createGraph(depth, to_visit, visited);
     }
@@ -82,7 +113,9 @@ namespace internal {
                     to_visit.push_back(&(connection_list.back()));
                 }
             } else {
-                port.port_name = node.connection_id->portName();
+                if (node.connection_id) {
+                    port.port_name = node.connection_id->portName();
+                }
             }
         }
     }
@@ -97,13 +130,18 @@ namespace internal {
     std::ostream& ConnectionIntrospector::printIndented(std::ostream& os,
             int i) const {
         const int currIndent = 4 * this->depth + i;
-        // For the first level (entry-point), only log the port.
-        if (this->depth == 0) {
+        if (this->depth == -1) {
+            // For depth -1, only log the component name.
+            os << std::string(i, ' ') << this->in_port.owner_name
+               << " COMPONENT\n";
+        } else if (this->depth == 0) {
+            // For depth 0, only log the port.
             os << std::string(currIndent, ' ')
                << (this->is_forward ? " IN " : " OUT ")
                << (this->is_forward ? this->in_port
                                          : this->out_port) << ":\n";
-        } else {
+        } else if (this->depth > 0) {
+            // Positive depth, log the full connection information.
             os << std::string(currIndent, ' ')
                << (this->is_forward ? " -> IN " : " <- OUT ")
                << (this->is_forward ? this->in_port

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -5,14 +5,20 @@ namespace internal {
 
     ConnectionIntrospector::ConnectionIntrospector(
             const ConnectionManager::ChannelDescriptor& descriptor,
+            const PortQualifier& port,
             bool forward, int curr_depth) {
         is_forward = forward;
         connection_id = descriptor.get<0>();
         connection_policy = descriptor.get<2>();
-        in_port = PortQualifier(
-                    descriptor.get<1>()->getOutputEndPoint()->getPort());
-        out_port = PortQualifier(
-                    descriptor.get<1>()->getInputEndPoint()->getPort());
+        if (is_forward) {
+            in_port = PortQualifier(
+                        descriptor.get<1>()->getOutputEndPoint()->getPort());
+            out_port = port;
+        } else {
+            in_port = port;
+            out_port = PortQualifier(
+                        descriptor.get<1>()->getInputEndPoint()->getPort());
+        }
         depth = curr_depth;
     }
 
@@ -107,7 +113,7 @@ namespace internal {
                      it != connections.end(); ++it) {
                     // Push back one connection, and add the node to the "to_visit" list.
                     ConnectionIntrospector
-                            conn_descriptor(*it, !node.is_forward, curr_depth + 1);
+                            conn_descriptor(*it, port, !node.is_forward, curr_depth + 1);
                     if (visited.count(conn_descriptor)) {
                         continue;
                     }

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -1,0 +1,134 @@
+#include "ConnectionIntrospector.hpp"
+
+namespace RTT {
+namespace internal {
+
+    ConnectionIntrospector::ConnectionIntrospector(
+            const ConnectionManager::ChannelDescriptor& descriptor,
+            bool forward, int curr_depth) {
+        is_forward = forward;
+        connection_id = descriptor.get<0>();
+        connection_policy = descriptor.get<2>();
+        in_port = PortQualifier(
+                    descriptor.get<1>()->getOutputEndPoint()->getPort());
+        out_port = PortQualifier(
+                    descriptor.get<1>()->getInputEndPoint()->getPort());
+        depth = curr_depth;
+    }
+    ConnectionIntrospector::ConnectionIntrospector(
+            const base::PortInterface* port) {
+        PortQualifier port_(port);
+        if (port_.is_forward) {
+            out_port = port_;
+        } else {
+            in_port = port_;
+        }
+        // This is the fake "incoming" port connection, so forward is the
+        // opposite of the port value.
+        is_forward = !port_.is_forward;
+        depth = 0;
+    }
+
+    bool ConnectionIntrospector::operator==(const ConnectionIntrospector& other)
+            const {
+        return this->in_port == other.in_port &&
+                this->out_port == other.out_port;
+    }
+
+    bool ConnectionIntrospector::operator<(const ConnectionIntrospector& other)
+            const {
+        if (out_port < other.out_port) return true;
+        if (other.out_port < out_port) return false;
+        return in_port < other.in_port;
+    }
+
+    void ConnectionIntrospector::createGraph(int depth) {
+        std::list<ConnectionIntrospector*> to_visit;
+        to_visit.push_back(this);
+        std::set<ConnectionIntrospector> visited;
+        createGraph(depth, to_visit, visited);
+    }
+
+    void ConnectionIntrospector::createGraph(
+            int depth,
+            std::list<ConnectionIntrospector*>& to_visit,
+            std::set<ConnectionIntrospector>& visited) {
+        if (depth < 1) {depth = 1;}
+
+        while (!to_visit.empty()) {
+            ConnectionIntrospector& node(*(to_visit.front()));
+            to_visit.pop_front();
+            int curr_depth = node.depth;
+            if (curr_depth >= depth) {
+                continue;
+            }
+            std::list<ConnectionIntrospector>& connection_list = node.sub_connections;
+            PortQualifier& port = node.is_forward ? node.in_port : node.out_port;
+
+            // Would be undefined for remote ports.
+            if (!port.is_remote) {
+                std::list<ConnectionManager::ChannelDescriptor>
+                        connections = port.port_ptr->getManager()->getConnections();
+                for (std::list<ConnectionManager::ChannelDescriptor>::const_iterator it = connections.begin();
+                     it != connections.end(); ++it) {
+                    // Push back one connection, and add the node to the "to_visit" list.
+                    ConnectionIntrospector
+                            conn_descriptor(*it, !node.is_forward, curr_depth + 1);
+                    if (visited.count(conn_descriptor)) {
+                        continue;
+                    }
+                    visited.insert(conn_descriptor);
+                    connection_list.push_back(conn_descriptor);
+                    to_visit.push_back(&(connection_list.back()));
+                }
+            } else {
+                port.port_name = node.connection_id->portName();
+            }
+        }
+    }
+
+    std::ostream& operator<<(
+            std::ostream& os,
+            const ConnectionIntrospector::PortQualifier& pq) {
+        os << pq.owner_name << "." << pq.port_name;
+        return os;
+    }
+
+    std::ostream& ConnectionIntrospector::printIndented(std::ostream& os,
+            int i) const {
+        const int currIndent = 4 * this->depth + i;
+        // For the first level (entry-point), only log the port.
+        if (this->depth == 0) {
+            os << std::string(currIndent, ' ')
+               << (this->is_forward ? " IN " : " OUT ")
+               << (this->is_forward ? this->in_port
+                                         : this->out_port) << ":\n";
+        } else {
+            os << std::string(currIndent, ' ')
+               << (this->is_forward ? " -> IN " : " <- OUT ")
+               << (this->is_forward ? this->in_port
+                                         : this->out_port)
+               << " : (" << this->connection_id->typeString()
+               << " = " << this->connection_policy << ")\n";
+        }
+        for (std::list< ConnectionIntrospector >::const_iterator
+                it = this->sub_connections.begin();
+             it != this->sub_connections.end(); ++it) {
+            os << *it;
+        }
+        return os;
+    }
+
+    boost::function<std::ostream&(std::ostream&)>
+    ConnectionIntrospector::indent(int i) const {
+        return boost::bind(&ConnectionIntrospector::printIndented, this, _1, i);
+    }
+
+    std::ostream& operator<<(
+            std::ostream& os,
+            const ConnectionIntrospector& descriptor) {
+        return descriptor.indent(0)(os);
+    }
+
+}  // namespace internal
+}  // namespace RTT

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -10,14 +10,27 @@ namespace internal {
         is_forward = forward;
         connection_id = descriptor.get<0>();
         connection_policy = descriptor.get<2>();
+        base::ChannelElementBase::shared_ptr elem = descriptor.get<1>();
         if (is_forward) {
-            in_port = PortQualifier(
-                        descriptor.get<1>()->getOutputEndPoint()->getPort());
+            while (elem && elem->getOutput()) {
+                elem = elem->getOutput();
+            }
+            if (elem->getPort()) {
+                in_port = PortQualifier(elem->getPort());
+            } else {
+                in_port = PortQualifier(elem.get(), true /*is_forward*/);
+            }
             out_port = port;
         } else {
             in_port = port;
-            out_port = PortQualifier(
-                        descriptor.get<1>()->getInputEndPoint()->getPort());
+            while (elem && elem->getInput()) {
+                elem = elem->getInput();
+            }
+            if (elem->getPort()) {
+                out_port = PortQualifier(elem->getPort());
+            } else {
+                out_port = PortQualifier(elem.get(), false /*is_forward*/);
+            }
         }
         depth = curr_depth;
     }

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -176,6 +176,9 @@ namespace internal {
         return os;
     }
 
+    std::map<std::string, std::string>
+            ConnectionIntrospector::PortQualifier::long_port_names;
+
     std::ostream& ConnectionIntrospector::toDot(std::ostream& os) const {
         std::map<std::string, std::set<PortQualifier> > component_to_ports;
         typedef std::string conn_id;
@@ -318,7 +321,10 @@ namespace internal {
             // Also add single node properties.
             for (std::set<PortQualifier>::const_iterator
                     it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
-                os << it2->toDot() << " [label=\"" << it2->port_name
+                os << it2->toDot() << " [label=\""
+                   << (PortQualifier::long_port_names.count(it2->port_name)
+                        ? PortQualifier::long_port_names.at(it2->port_name)
+                        : it2->port_name)
                    << "\"];\n";
             }
         }

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -358,7 +358,10 @@ namespace internal {
     std::ostream& operator<<(
             std::ostream& os,
             const ConnectionIntrospector::PortQualifier& pq) {
-        os << pq.owner_name << "." << pq.port_name;
+        os << pq.owner_name << "."
+           << (ConnectionIntrospector::PortQualifier::long_port_names.count(pq.port_name)
+                ? ConnectionIntrospector::PortQualifier::long_port_names[pq.port_name]
+                : pq.port_name);
         return os;
     }
 

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -41,7 +41,7 @@ namespace internal {
         in_port.owner_name = tc->getName();
         is_forward = true;
         depth = -1;
-        if (tc->ports()) {
+        if (tc->ports() && !(tc->ports()->getPortNames().empty())) {
             DataFlowInterface::PortNames port_names = tc->ports()->getPortNames();
             for (size_t j = 0; j < port_names.size(); ++j) {
                 const std::string& port_name = port_names.at(j);
@@ -49,6 +49,9 @@ namespace internal {
                 ConnectionIntrospector ci(port_ptr);
                 sub_connections.push_back(ci);
             }
+            in_port.is_remote = false;
+        } else {
+            in_port.is_remote = true;
         }
     }
 

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -89,6 +89,11 @@ namespace internal {
         createGraph(depth, to_visit, visited);
     }
 
+    void ConnectionIntrospector::addSubConnection(
+            const ConnectionIntrospector& other) {
+        this->sub_connections.push_back(other);
+    }
+
     void ConnectionIntrospector::createGraph(
             int depth,
             std::list<ConnectionIntrospector*>& to_visit,

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -107,24 +107,36 @@ namespace internal {
             if (curr_depth >= depth) {
                 continue;
             }
-            std::list<ConnectionIntrospector>& connection_list = node.sub_connections;
             PortQualifier& port = node.is_forward ? node.in_port : node.out_port;
 
             // Would be undefined for remote ports.
             if (!port.is_remote) {
-                std::list<ConnectionManager::ChannelDescriptor>
-                        connections = port.port_ptr->getManager()->getConnections();
-                for (std::list<ConnectionManager::ChannelDescriptor>::const_iterator it = connections.begin();
-                     it != connections.end(); ++it) {
-                    // Push back one connection, and add the node to the "to_visit" list.
-                    ConnectionIntrospector
-                            conn_descriptor(*it, port, !node.is_forward, curr_depth + 1);
-                    if (visited.count(conn_descriptor)) {
+                std::list<ConnectionIntrospector> ci_list;
+                if (!node.sub_connections.empty()) {
+                    // Inspecting an already created list, append extra connections.
+                    ci_list.insert(ci_list.end(), node.sub_connections.begin(),
+                                   node.sub_connections.end());
+                    node.sub_connections.clear();
+                } else if (port.port_ptr && port.port_ptr->getManager()) {
+                    // Perform conversion from ChannelDescriptor.
+                    std::list<ConnectionManager::ChannelDescriptor>
+                            connections = port.port_ptr->getManager()->getConnections();
+                    for (std::list<ConnectionManager::ChannelDescriptor>::const_iterator
+                            it = connections.begin(); it != connections.end(); ++it) {
+                        ci_list.push_back(ConnectionIntrospector(
+                                *it, port, !node.is_forward, curr_depth + 1));
+                    }
+                }
+                // Check whether connections have already been visited,
+                // otherwise add them to the to_visit list.
+                for (std::list<ConnectionIntrospector>::const_iterator
+                        it = ci_list.begin(); it != ci_list.end(); ++it) {
+                    if (visited.count(*it)) {
                         continue;
                     }
-                    visited.insert(conn_descriptor);
-                    connection_list.push_back(conn_descriptor);
-                    to_visit.push_back(&(connection_list.back()));
+                    visited.insert(*it);
+                    node.sub_connections.push_back(*it);
+                    to_visit.push_back(&(node.sub_connections.back()));
                 }
             } else {
                 if (node.connection_id) {

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -65,14 +65,15 @@ public:
 
         std::string toDot() const {
             const std::string separator = "___";
-            std::string owner_clean = owner_name;
-            if (owner_clean[0] == '{') {
-                owner_clean[0] = '_';
+            const std::string chars_to_replace = "{}/:";
+            std::string dot_name = owner_name + separator + port_name;
+            for (size_t i = 0; i < chars_to_replace.size(); ++i) {
+                char c = chars_to_replace[i];
+                while(dot_name.find(c) != dot_name.npos) {
+                    dot_name[dot_name.find(c)] = '_';
+                }
             }
-            if (owner_clean[owner_clean.size()-1] == '}') {
-                owner_clean[owner_clean.size()-1] = '_';
-            }
-            return owner_clean + separator + port_name;
+            return dot_name;
         }
 
         friend std::ostream& operator<<(std::ostream& os, const PortQualifier&);

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -27,6 +27,7 @@ public:
         const base::PortInterface* port_ptr;
         bool is_forward;
         bool is_remote;
+        static std::map<std::string, std::string> long_port_names;
 
         PortQualifier() {}
         PortQualifier(const base::PortInterface* port)
@@ -71,6 +72,10 @@ public:
             } else {
                 owner_name = "{UNKNOWN_OWNER}";
             }
+            if (port_name.length() > 15 && !long_port_names.count(port_name)) {
+                long_port_names[port_name] =
+                        "LONG_PORT_NAME_" + std::to_string(long_port_names.size());
+            }
         }
 
         bool operator==(const PortQualifier& other) const {
@@ -88,7 +93,10 @@ public:
         std::string toDot() const {
             const std::string separator = "___";
             const std::string chars_to_replace = "{}/:";
-            std::string dot_name = owner_name + separator + port_name;
+            std::string dot_name = owner_name + separator +
+                    (long_port_names.count(port_name)
+                            ? long_port_names.at(port_name)
+                            : port_name);
             for (size_t i = 0; i < chars_to_replace.size(); ++i) {
                 char c = chars_to_replace[i];
                 while(dot_name.find(c) != dot_name.npos) {

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -70,6 +70,7 @@ public:
             const ConnectionManager::ChannelDescriptor& descriptor,
             bool forward, int curr_depth);
     ConnectionIntrospector(const base::PortInterface* port);
+    ConnectionIntrospector(const TaskContext* tc);
 
     bool operator==(const ConnectionIntrospector& other) const;
 

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -63,6 +63,18 @@ public:
             return port_name < other.port_name;
         }
 
+        std::string toDot() const {
+            const std::string separator = "___";
+            std::string owner_clean = owner_name;
+            if (owner_clean[0] == '{') {
+                owner_clean[0] = '_';
+            }
+            if (owner_clean[owner_clean.size()-1] == '}') {
+                owner_clean[owner_clean.size()-1] = '_';
+            }
+            return owner_clean + separator + port_name;
+        }
+
         friend std::ostream& operator<<(std::ostream& os, const PortQualifier&);
     };
 
@@ -89,7 +101,8 @@ public:
     void createGraph(int depth, std::list<ConnectionIntrospector*>& to_visit,
         std::set<ConnectionIntrospector>& visited);
 
-//    void createDot(const std::string& file_name);
+    // Writes to stream a dot graph representation of this object.
+    std::ostream& toDot(std::ostream& os) const;
 
     friend std::ostream& operator<<(std::ostream& os,
                                     const ConnectionIntrospector&);

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -68,6 +68,7 @@ public:
 
     ConnectionIntrospector(
             const ConnectionManager::ChannelDescriptor& descriptor,
+            const PortQualifier& port,
             bool forward, int curr_depth);
     ConnectionIntrospector(const base::PortInterface* port);
     ConnectionIntrospector(const TaskContext* tc);

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -51,6 +51,28 @@ public:
             }
         }
 
+        // Constructing from a channel element when a port is not available, so
+        // we are dealing with a remote port.
+        PortQualifier(const base::ChannelElementBase* elem, bool is_forward)
+                : port_ptr(NULL), is_forward(is_forward), is_remote(true) {
+            assert(!elem->getPort());
+            port_name = elem->getRemoteURI();
+            if (elem->getElementName() == "RosPubChannelElement") {
+                owner_name = "ROS";
+                assert(is_forward);
+            } else if (elem->getElementName() == "RosSubChannelElement") {
+                owner_name = "ROS";
+                port_name = elem->getRemoteURI();
+                assert(!is_forward);
+            } else if (elem->getElementName() == "CorbaRemoteChannelElement") {
+                owner_name = "CORBA";
+            } else if (elem->getElementName() == "MQChannelElement") {
+                owner_name = "MQ";
+            } else {
+                owner_name = "{UNKNOWN_OWNER}";
+            }
+        }
+
         bool operator==(const PortQualifier& other) const {
             // For simplicity, remote ports are always different for now.
             return !this->is_remote && this->owner_name == other.owner_name &&

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -1,0 +1,109 @@
+#ifndef CONNECTIONINTROSPECTOR_HPP
+#define CONNECTIONINTROSPECTOR_HPP
+
+#include "ConnID.hpp"
+#include "ConnectionManager.hpp"
+#include <boost/shared_ptr.hpp>
+#include "../base/InputPortInterface.hpp"
+#include "../base/PortInterface.hpp"
+#include "../DataFlowInterface.hpp"
+#include "../TaskContext.hpp"
+
+#include <list>
+#include <set>
+
+namespace RTT
+{
+
+namespace internal
+{
+
+class ConnectionIntrospector
+{
+public:
+    struct PortQualifier {
+        std::string owner_name;
+        std::string port_name;
+        const base::PortInterface* port_ptr;
+        bool is_forward;
+        bool is_remote;
+
+        PortQualifier() {}
+        PortQualifier(const base::PortInterface* port)
+                : port_ptr(port), is_remote(false) {
+            // When the port is invalid, we have a remote port.
+            if (!port_ptr) {
+                port_name = "{REMOTE_PORT}";
+                owner_name = "{REMOTE_OWNER}";
+                is_remote = true;
+                return;
+            }
+            port_name = port_ptr->getName();
+            if (port_ptr->getInterface()) {
+                owner_name = port_ptr->getInterface()->getOwner()->getName();
+            } else {
+                owner_name = "{FREE}";
+            }
+            if ( dynamic_cast<const base::InputPortInterface*>(port_ptr) ) {
+                is_forward = false;
+            } else {
+                is_forward = true;
+            }
+        }
+
+        bool operator==(const PortQualifier& other) const {
+            // For simplicity, remote ports are always different for now.
+            return !this->is_remote && this->owner_name == other.owner_name &&
+                    this->port_name == other.port_name;
+        }
+
+        bool operator<(const PortQualifier& other) const {
+            if (owner_name < other.owner_name) return true;
+            if (owner_name > other.owner_name) return false;
+            return port_name < other.port_name;
+        }
+
+        friend std::ostream& operator<<(std::ostream& os, const PortQualifier&);
+    };
+
+    ConnectionIntrospector(
+            const ConnectionManager::ChannelDescriptor& descriptor,
+            bool forward, int curr_depth);
+    ConnectionIntrospector(const base::PortInterface* port);
+
+    bool operator==(const ConnectionIntrospector& other) const;
+
+    bool operator<(const ConnectionIntrospector& other) const;
+
+    void createGraph(int depth = 1);
+
+    boost::function<std::ostream&(std::ostream&)> indent(int i) const;
+
+    std::ostream& printIndented(std::ostream& os, int i) const;
+
+    void createGraph(int depth, std::list<ConnectionIntrospector*>& to_visit,
+        std::set<ConnectionIntrospector>& visited);
+
+//    void createDot(const std::string& file_name);
+
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const ConnectionIntrospector&);
+
+private:
+    ConnectionIntrospector();
+
+    bool is_forward;
+    PortQualifier in_port;
+    PortQualifier out_port;
+    boost::shared_ptr<ConnID> connection_id;  // Can be casted to port if local
+    // std::string connection_name;
+    ConnPolicy connection_policy;
+    int depth;
+    std::list<ConnectionIntrospector> sub_connections;
+};
+
+}  // namespace internal
+
+}  // namespace RTT
+
+#endif // CONNECTIONINTROSPECTOR_HPP

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -83,6 +83,9 @@ public:
 
     std::ostream& printIndented(std::ostream& os, int i) const;
 
+    // Manually add a sub-connection to this ConnectionIntrospector object.
+    void addSubConnection(const ConnectionIntrospector& other);
+
     void createGraph(int depth, std::list<ConnectionIntrospector*>& to_visit,
         std::set<ConnectionIntrospector>& visited);
 

--- a/rtt/internal/SharedConnection.cpp
+++ b/rtt/internal/SharedConnection.cpp
@@ -63,6 +63,16 @@ ConnID* SharedConnID::clone() const
     return new SharedConnID(this->connection);
 }
 
+std::string SharedConnID::typeString() const
+{
+    return "SharedConnID";
+}
+
+std::string SharedConnID::portName() const
+{
+    return this->connection->getName();
+}
+
 #ifdef ORO_HAVE_BOOST_UUID
 static boost::uuids::random_generator uuid_generator;
 #endif

--- a/rtt/internal/SharedConnection.hpp
+++ b/rtt/internal/SharedConnection.hpp
@@ -60,6 +60,8 @@ namespace internal {
             : connection(connection) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
+        virtual std::string typeString() const;
+        virtual std::string portName() const;
         template <typename T> boost::intrusive_ptr< SharedConnection<T> > getConnection() const
         {
             return boost::static_pointer_cast< SharedConnection<T> >(connection);

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -487,15 +487,24 @@ namespace RTT {
                 return true;
             }
             
-            
             virtual std::string getRemoteURI() const
             {
+                //check for output element case
+                RTT::base::ChannelElementBase *base = const_cast<RemoteChannelElement<T> *>(this);
+                if(base->getOutput())
+                    return RTT::base::ChannelElementBase::getRemoteURI();
+                
                 std::string uri = ApplicationServer::orb->object_to_string(remote_side);
                 return uri;
             }
             
             virtual std::string getLocalURI() const
             {
+                //check for input element case
+                RTT::base::ChannelElementBase *base = const_cast<RemoteChannelElement<T> *>(this);
+                if(base->getInput())
+                    return RTT::base::ChannelElementBase::getLocalURI();
+                
                 return localUri;
             }
             

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -43,6 +43,7 @@
 #include "CorbaTypeTransporter.hpp"
 #include "CorbaDispatcher.hpp"
 #include "CorbaConnPolicy.hpp"
+#include "ApplicationServer.hpp"
 
 namespace RTT {
 
@@ -72,6 +73,8 @@ namespace RTT {
 
         ConnPolicy policy;
 
+        std::string localUri;
+
         public:
             /**
              * Create a channel element for remote data exchange.
@@ -93,6 +96,8 @@ namespace RTT {
                 oid = mpoa->activate_object(this);
                 // Force creation of dispatcher.
                 CorbaDispatcher::Instance(msender);
+                
+                localUri = ApplicationServer::orb->object_to_string(_this());
             }
 
             ~RemoteChannelElement()
@@ -475,6 +480,28 @@ namespace RTT {
             {
                 ConnPolicy policy = toRTT(cp);
                 return base::ChannelElement<T>::channelReady(this, policy);
+            }
+
+            virtual bool isRemoteElement() const
+            {
+                return true;
+            }
+            
+            
+            virtual std::string getRemoteURI() const
+            {
+                std::string uri = ApplicationServer::orb->object_to_string(remote_side);
+                return uri;
+            }
+            
+            virtual std::string getLocalURI() const
+            {
+                return localUri;
+            }
+            
+            virtual std::string getElementName() const
+            {
+                return "CorbaRemoteChannelElement";
             }
         };
     }

--- a/rtt/transports/corba/RemoteConnID.cpp
+++ b/rtt/transports/corba/RemoteConnID.cpp
@@ -61,3 +61,11 @@ bool RemoteConnID::isSameID(ConnID const& id) const
 RTT::internal::ConnID* RemoteConnID::clone() const {
     return new RemoteConnID( this->dataflow.in(), this->name);
 }
+
+std::string RemoteConnID::typeString() const {
+    return "RemoteConnID";
+}
+
+std::string RemoteConnID::portName() const {
+    return name;
+}

--- a/rtt/transports/corba/RemoteConnID.hpp
+++ b/rtt/transports/corba/RemoteConnID.hpp
@@ -66,6 +66,8 @@ namespace RTT
 
             bool isSameID(ConnID const& id) const;
             ConnID* clone() const;
+            virtual std::string typeString() const;
+            virtual std::string portName() const;
         };
 
     }

--- a/rtt/transports/mqueue/MQChannelElement.hpp
+++ b/rtt/transports/mqueue/MQChannelElement.hpp
@@ -168,6 +168,25 @@ namespace RTT
                 return WriteSuccess;
             }
 
+            virtual bool isRemoteElement() const
+            {
+                return true;
+            }
+            
+            virtual std::string getRemoteURI() const
+            {
+                return mqname;
+            }
+
+            virtual std::string getLocalURI() const
+            {
+                return mqname;
+            }
+
+            virtual std::string getElementName() const
+            {
+                return "MQChannelElement";
+            }
         };
     }
 }

--- a/rtt/transports/mqueue/MQChannelElement.hpp
+++ b/rtt/transports/mqueue/MQChannelElement.hpp
@@ -175,11 +175,21 @@ namespace RTT
             
             virtual std::string getRemoteURI() const
             {
+                //check for output element case
+                RTT::base::ChannelElementBase *base = const_cast<MQChannelElement<T> *>(this);
+                if(base->getOutput())
+                    return RTT::base::ChannelElementBase::getRemoteURI();
+                
                 return mqname;
             }
 
             virtual std::string getLocalURI() const
             {
+                //check for input element case
+                RTT::base::ChannelElementBase *base = const_cast<MQChannelElement<T> *>(this);
+                if(base->getInput())
+                    return RTT::base::ChannelElementBase::getLocalURI();
+
                 return mqname;
             }
 


### PR DESCRIPTION
This PR implements connection introspection on top or `rdt-toolchain-2.9`. For remote connections it uses the ability introduced with [ddce764](https://github.com/Intermodalics/rtt/commit/ddce764bbc389131f09d1d3dbd8a32c583499a4c), coupled with [rtt_ros_integration/PR1](https://github.com/Intermodalics/rtt_ros_integration/pull/1) for stream connections.