### PR TITLE
Connection introspection (rdt-toolchain-2.9)

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -105,7 +105,7 @@ namespace RTT
 
         this->addOperation("trigger", &TaskContext::trigger, this, ClientThread).doc("Trigger the update method for execution in the thread of this task.\n Only succeeds if the task isRunning() and allowed by the Activity executing this task.");
         this->addOperation("loadService", &TaskContext::loadService, this, ClientThread).doc("Loads a service known to RTT into this component.").arg("service_name","The name with which the service is registered by in the PluginLoader.");
-        this->addOperation("port_connections", &TaskContext::listPortConnections, this, ClientThread).doc("Logs a list of connections for all ports in this component.")
+        this->addOperation("showPortConnections", &TaskContext::showPortConnections, this, ClientThread).doc("Logs a list of connections for all ports in this component.")
                 .arg("depth", "Number of levels to look for: 1 will only list direct connections, more than 1 will also look at connected ports connections.");
 
         this->addAttribute("TriggerOnStart",mTriggerOnStart);
@@ -454,7 +454,7 @@ namespace RTT
         }
     }
 
-    void TaskContext::listPortConnections(int depth) const
+    void TaskContext::showPortConnections(int depth) const
     {
         if (depth < 1) {depth = 1;}
 

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -47,6 +47,7 @@
 #include <boost/bind.hpp>
 #include <boost/mem_fn.hpp>
 
+#include "internal/ConnectionIntrospector.hpp"
 #include "internal/DataSource.hpp"
 #include "internal/mystd.hpp"
 #include "internal/MWSRQueue.hpp"
@@ -104,6 +105,8 @@ namespace RTT
 
         this->addOperation("trigger", &TaskContext::trigger, this, ClientThread).doc("Trigger the update method for execution in the thread of this task.\n Only succeeds if the task isRunning() and allowed by the Activity executing this task.");
         this->addOperation("loadService", &TaskContext::loadService, this, ClientThread).doc("Loads a service known to RTT into this component.").arg("service_name","The name with which the service is registered by in the PluginLoader.");
+        this->addOperation("port_connections", &TaskContext::listPortConnections, this, ClientThread).doc("Logs a list of connections for all ports in this component.")
+                .arg("depth", "Number of levels to look for: 1 will only list direct connections, more than 1 will also look at connected ports connections.");
 
         this->addAttribute("TriggerOnStart",mTriggerOnStart);
         this->addAttribute("CycleCounter",mCycleCounter);
@@ -449,6 +452,15 @@ namespace RTT
         if (it != user_callbacks.end() ) {
             user_callbacks.erase(it);
         }
+    }
+
+    void TaskContext::listPortConnections(int depth) const
+    {
+        if (depth < 1) {depth = 1;}
+
+        ConnectionIntrospector ci(this);
+        ci.createGraph(depth);
+        std::cout << "\n" << ci << std::endl;
     }
 }
 

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -697,7 +697,7 @@ namespace RTT
          * @param depth Levels to explore: 1 (or less) will only explore direct
          *              connections.
          */
-        void listPortConnections(int depth) const;
+        void showPortConnections(int depth) const;
     };
 
     /**

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -691,6 +691,13 @@ namespace RTT
          * setActivity. By default, a extras::SequentialActivity is assigned.
          */
         base::ActivityInterface::shared_ptr our_act;
+
+        /**
+         * Lists all connections this component' ports have, up to depth levels.
+         * @param depth Levels to explore: 1 (or less) will only explore direct
+         *              connections.
+         */
+        void listPortConnections(int depth) const;
     };
 
     /**

--- a/rtt/base/ChannelElementBase.hpp
+++ b/rtt/base/ChannelElementBase.hpp
@@ -130,7 +130,6 @@ namespace RTT { namespace base {
          */
         virtual shared_ptr getInputEndPoint();
 
-
         /** Returns the next channel element in the channel's propagation
          * direction
          */
@@ -390,6 +389,11 @@ namespace RTT { namespace base {
          */
         bool signalFrom(ChannelElementBase *caller);
 
+        /**
+         * Returns a list of input elements.
+         */
+        Inputs getInputs() const;
+
     protected:
         /**
          * Sets the new input channel element of this element or adds a channel to the inputs list.
@@ -452,6 +456,11 @@ namespace RTT { namespace base {
          * Overridden implementation of \ref ChannelElementBase::disconnect(forward, channel).
          */
         virtual bool disconnect(ChannelElementBase::shared_ptr const& channel, bool forward = false);
+
+        /**
+         * Returns a list of output elements.
+         */
+        Outputs getOutputs() const;
 
     protected:
         /**

--- a/rtt/base/ChannelInterface.cpp
+++ b/rtt/base/ChannelInterface.cpp
@@ -340,6 +340,12 @@ bool MultipleInputsChannelElementBase::signalFrom(ChannelElementBase *caller)
     return signal();
 }
 
+MultipleInputsChannelElementBase::Inputs MultipleInputsChannelElementBase::getInputs() const
+{
+    RTT::os::MutexLock lock(inputs_lock);
+    return inputs;
+}
+
 MultipleOutputsChannelElementBase::MultipleOutputsChannelElementBase()
 {}
 
@@ -449,6 +455,12 @@ void MultipleOutputsChannelElementBase::removeDisconnectedOutputs()
             removeOutput(output.channel.get()); // invalidates output
         }
     }
+}
+
+MultipleOutputsChannelElementBase::Outputs MultipleOutputsChannelElementBase::getOutputs() const
+{
+    RTT::os::MutexLock lock(outputs_lock);
+    return outputs;
 }
 
 bool MultipleInputsMultipleOutputsChannelElementBase::connected()

--- a/rtt/base/PortInterface.cpp
+++ b/rtt/base/PortInterface.cpp
@@ -58,6 +58,23 @@ bool PortInterface::setName(const std::string& name)
     return false;
 }
 
+std::string PortInterface::getQualifiedName() const
+{
+    std::string qualified_name = getName();
+    const RTT::DataFlowInterface *interface = getInterface();
+    if (!interface) return qualified_name;
+
+    const RTT::Service *service = interface->getService();
+    while(service) {
+        if (!service->getName().empty()) {
+            qualified_name = service->getName() + "." + qualified_name;
+        }
+        service = service->getParent().get();
+    }
+
+    return qualified_name;
+}
+
 PortInterface& PortInterface::doc(const std::string& desc) {
     mdesc = desc;
     if (iface)

--- a/rtt/base/PortInterface.cpp
+++ b/rtt/base/PortInterface.cpp
@@ -138,7 +138,7 @@ internal::SharedConnectionBase::shared_ptr PortInterface::getSharedConnection() 
 
 void PortInterface::showPortConnections(int depth) const
 {
-    if (depth < 1) {depth = 1;}
+    if (depth < 1) depth = 1;
 
     ConnectionIntrospector ci(this);
     ci.createGraph(depth);

--- a/rtt/base/PortInterface.cpp
+++ b/rtt/base/PortInterface.cpp
@@ -88,9 +88,8 @@ Service* PortInterface::createPortObject()
     typedef void (PortInterface::*disconnect_all)();
     to->addSynchronousOperation("disconnect", static_cast<disconnect_all>(&PortInterface::disconnect), this).doc("Disconnects this port from any connection it is part of.");
 
-    typedef void (PortInterface::*PortConnections)(int) const;
-    PortConnections port_connections = &PortInterface::listPortConnections;
-    to->addSynchronousOperation("port_connections", port_connections, this).doc(
+    to->addSynchronousOperation("showPortConnections",
+        &PortInterface::showPortConnections, this).doc(
             "Logs a list of connections for this port.").arg(
                 "depth", "Number of levels to look for: 1 will only list direct"
                 " connections, more than 1 will also look at connected ports "
@@ -120,7 +119,7 @@ internal::SharedConnectionBase::shared_ptr PortInterface::getSharedConnection() 
     return cmanager.getSharedConnection();
 }
 
-void PortInterface::listPortConnections(int depth) const
+void PortInterface::showPortConnections(int depth) const
 {
     if (depth < 1) {depth = 1;}
 

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -238,6 +238,14 @@ namespace RTT
          * Returns a pointer to the shared connection element this port may be connected to.
          */
         virtual internal::SharedConnectionBase::shared_ptr getSharedConnection() const;
+
+    private:
+        /**
+         * @brief Lists all connections this port has, up to depth levels.
+         * @param depth Levels to explore: 1 (or less) will only explore direct
+         *              connections.
+         */
+        void listPortConnections(int depth) const;
     };
 
 }}

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -87,6 +87,14 @@ namespace RTT
         bool setName(const std::string& name);
 
         /**
+         * Gets the qualified name of this Port.
+         * The qualified name starts with the owner's name (if any),
+         * eventually intermediate services and finally the port's name,
+         * separated by dots.
+         */
+        std::string getQualifiedName() const;
+
+        /**
          * Get the documentation of this port.
          * @return A description.
          */

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -245,7 +245,7 @@ namespace RTT
          * @param depth Levels to explore: 1 (or less) will only explore direct
          *              connections.
          */
-        void listPortConnections(int depth) const;
+        void showPortConnections(int depth) const;
     };
 
 }}

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -216,10 +216,16 @@ namespace RTT
          * in order to allow connection introspection.
          * @return null if no such manager is available, or the manager
          * otherwise.
-         * @see ConnectionManager::getChannels() for a list of all
+         * @see ConnectionManager::getConnections() for a list of all
          * connections of this port.
          */
         virtual internal::ConnectionManager* getManager() { return &cmanager; }
+
+        /**
+         * Const variant of getManager().
+         * @copydoc getManager()
+         */
+        virtual const internal::ConnectionManager* getManager() const { return &cmanager; }
 
         /**
          * Returns the input or output endpoint of this port (if any).

--- a/rtt/internal/ConnFactory.cpp
+++ b/rtt/internal/ConnFactory.cpp
@@ -58,6 +58,10 @@ ConnID* LocalConnID::clone() const {
     return new LocalConnID(this->ptr);
 }
 
+std::string LocalConnID::typeString() const {
+    return "LocalConnID";
+}
+
 bool StreamConnID::isSameID(ConnID const& id) const
 {
     StreamConnID const* real_id = dynamic_cast<StreamConnID const*>(&id);
@@ -68,6 +72,14 @@ bool StreamConnID::isSameID(ConnID const& id) const
 
 ConnID* StreamConnID::clone() const {
     return new StreamConnID(this->name_id);
+}
+
+std::string StreamConnID::typeString() const {
+    return "StreamConnID";
+}
+
+std::string StreamConnID::portName() const {
+    return this->name_id;
 }
 
 base::ChannelElementBase::shared_ptr RTT::internal::ConnFactory::buildRemoteChannelOutput(base::OutputPortInterface& output_port, base::InputPortInterface& input_port, const ConnPolicy& policy)

--- a/rtt/internal/ConnFactory.cpp
+++ b/rtt/internal/ConnFactory.cpp
@@ -58,12 +58,8 @@ ConnID* LocalConnID::clone() const {
     return new LocalConnID(this->ptr);
 }
 
-std::string LocalConnID::typeString() const {
-    return "LocalConnID";
-}
-
-std::string LocalConnID::portName() const {
-    return this->ptr->getName();
+const base::PortInterface *LocalConnID::getPort() const {
+    return this->ptr;
 }
 
 bool StreamConnID::isSameID(ConnID const& id) const
@@ -78,11 +74,7 @@ ConnID* StreamConnID::clone() const {
     return new StreamConnID(this->name_id);
 }
 
-std::string StreamConnID::typeString() const {
-    return "StreamConnID";
-}
-
-std::string StreamConnID::portName() const {
+std::string StreamConnID::getName() const {
     return this->name_id;
 }
 

--- a/rtt/internal/ConnFactory.cpp
+++ b/rtt/internal/ConnFactory.cpp
@@ -62,6 +62,10 @@ std::string LocalConnID::typeString() const {
     return "LocalConnID";
 }
 
+std::string LocalConnID::portName() const {
+    return this->ptr->getName();
+}
+
 bool StreamConnID::isSameID(ConnID const& id) const
 {
     StreamConnID const* real_id = dynamic_cast<StreamConnID const*>(&id);

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -70,6 +70,7 @@ namespace RTT
             : ptr(obj) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
+        virtual std::string typeString() const;
     };
 
     /**
@@ -82,6 +83,8 @@ namespace RTT
             : name_id(name) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
+        virtual std::string typeString() const;
+        virtual std::string portName() const;
     };
 
 

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -65,13 +65,12 @@ namespace RTT
      */
     struct LocalConnID : public ConnID
     {
-        base::PortInterface const* ptr;
+        const base::PortInterface * const ptr;
         LocalConnID(base::PortInterface const* obj)
             : ptr(obj) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
-        virtual std::string typeString() const;
-        virtual std::string portName() const;
+        virtual const base::PortInterface *getPort() const;
     };
 
     /**
@@ -84,8 +83,7 @@ namespace RTT
             : name_id(name) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
-        virtual std::string typeString() const;
-        virtual std::string portName() const;
+        virtual std::string getName() const;
     };
 
 

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -71,6 +71,7 @@ namespace RTT
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
         virtual std::string typeString() const;
+        virtual std::string portName() const;
     };
 
     /**

--- a/rtt/internal/ConnID.cpp
+++ b/rtt/internal/ConnID.cpp
@@ -44,11 +44,29 @@
  */
 
 #include "ConnID.hpp"
+#include <rtt/base/PortInterface.hpp>
+#include <rtt/DataFlowInterface.hpp>
+#include <rtt/TaskContext.hpp>
 
+using namespace RTT;
 using namespace RTT::internal;
 
-std::string ConnID::portName() const {
-    return "";
+std::string ConnID::getName() const {
+    const base::PortInterface * const port = getPort();
+    if (!port) return std::string();
+
+    const RTT::DataFlowInterface * const iface = port->getInterface();
+    if (iface) {
+        RTT::TaskContext *owner = iface->getOwner();
+        if (owner) {
+            return owner->getName() + "." + port->getName();
+        }
+    }
+    return port->getName();
+}
+
+const base::PortInterface *ConnID::getPort() const {
+    return 0;
 }
 
 SimpleConnID::SimpleConnID(const ConnID* orig ) : cid( orig == 0 ? this : orig) {}
@@ -60,8 +78,4 @@ bool SimpleConnID::isSameID(ConnID const& id) const {
 }
 ConnID* SimpleConnID::clone() const {
     return new SimpleConnID( this->cid );
-}
-
-std::string SimpleConnID::typeString() const {
-    return "SimpleConnID";
 }

--- a/rtt/internal/ConnID.cpp
+++ b/rtt/internal/ConnID.cpp
@@ -54,15 +54,7 @@ using namespace RTT::internal;
 std::string ConnID::getName() const {
     const base::PortInterface * const port = getPort();
     if (!port) return std::string();
-
-    const RTT::DataFlowInterface * const iface = port->getInterface();
-    if (iface) {
-        RTT::TaskContext *owner = iface->getOwner();
-        if (owner) {
-            return owner->getName() + "." + port->getName();
-        }
-    }
-    return port->getName();
+    return port->getQualifiedName();
 }
 
 const base::PortInterface *ConnID::getPort() const {

--- a/rtt/internal/ConnID.cpp
+++ b/rtt/internal/ConnID.cpp
@@ -47,6 +47,10 @@
 
 using namespace RTT::internal;
 
+std::string ConnID::portName() const {
+    return "";
+}
+
 SimpleConnID::SimpleConnID(const ConnID* orig ) : cid( orig == 0 ? this : orig) {}
 bool SimpleConnID::isSameID(ConnID const& id) const {
     SimpleConnID const* real_id = dynamic_cast<SimpleConnID const*>(&id);
@@ -56,4 +60,8 @@ bool SimpleConnID::isSameID(ConnID const& id) const {
 }
 ConnID* SimpleConnID::clone() const {
     return new SimpleConnID( this->cid );
+}
+
+std::string SimpleConnID::typeString() const {
+    return "SimpleConnID";
 }

--- a/rtt/internal/ConnID.hpp
+++ b/rtt/internal/ConnID.hpp
@@ -47,6 +47,7 @@
 #define ORO_CONNID_HPP_
 
 #include "../rtt-config.h"
+#include "../rtt-fwd.hpp"
 #include <string>
 
 namespace RTT
@@ -62,8 +63,8 @@ namespace RTT
             virtual bool isSameID(ConnID const& id) const = 0;
             virtual ConnID* clone() const = 0;
             virtual ~ConnID() {}
-            virtual std::string typeString() const = 0;
-            virtual std::string portName() const;
+            virtual std::string getName() const;
+            virtual const base::PortInterface *getPort() const;
         };
 
         /**
@@ -76,7 +77,6 @@ namespace RTT
             SimpleConnID(const ConnID* orig = 0);
             virtual bool isSameID(ConnID const& id) const;
             virtual ConnID* clone() const;
-            virtual std::string typeString() const;
         };
     }
 }

--- a/rtt/internal/ConnID.hpp
+++ b/rtt/internal/ConnID.hpp
@@ -47,6 +47,7 @@
 #define ORO_CONNID_HPP_
 
 #include "../rtt-config.h"
+#include <string>
 
 namespace RTT
 {
@@ -61,6 +62,8 @@ namespace RTT
             virtual bool isSameID(ConnID const& id) const = 0;
             virtual ConnID* clone() const = 0;
             virtual ~ConnID() {}
+            virtual std::string typeString() const = 0;
+            virtual std::string portName() const;
         };
 
         /**
@@ -73,6 +76,7 @@ namespace RTT
             SimpleConnID(const ConnID* orig = 0);
             virtual bool isSameID(ConnID const& id) const;
             virtual ConnID* clone() const;
+            virtual std::string typeString() const;
         };
     }
 }

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -1,248 +1,307 @@
 #include "ConnectionIntrospector.hpp"
 
+#include "../Port.hpp"
+#include "../TaskContext.hpp"
+
+#include <cassert>
+
 namespace RTT {
+
+// forward declaration of corba::RemoteConnID
+namespace corba {
+   class RemoteConnID;
+}
+
 namespace internal {
 
-    ConnectionIntrospector::PortQualifier::PortQualifier() {}
-    ConnectionIntrospector::PortQualifier::PortQualifier(const base::PortInterface* port)
-            : port_ptr(port), is_remote(false) {
-        // If the port is invalid, we have a remote port.
-        if (!port_ptr) {
-            port_name = "{REMOTE_PORT}";
-            owner_name = "{REMOTE_OWNER}";
-            is_remote = true;
-            return;
-        }
-        port_name = port_ptr->getName();
-        if (port_ptr->getInterface() && port_ptr->getInterface()->getOwner()) {
-            owner_name = port_ptr->getInterface()->getOwner()->getName();
-        } else {
-            owner_name = "{FREE}";
-        }
-        if ( dynamic_cast<const base::InputPortInterface*>(port_ptr) ) {
-            is_forward = false;
-        } else {
-            is_forward = true;
-        }
+ConnectionIntrospector::Node::Node(base::ChannelElementBase *endpoint, const std::string &name)
+    : direction_(Unspecified), endpoint_(endpoint), name_(name) {}
+
+ConnectionIntrospector::Node::~Node() {}
+
+inline base::ChannelElementBase::shared_ptr ConnectionIntrospector::Node::getEndpoint() const {
+    return endpoint_;
+}
+
+inline std::string ConnectionIntrospector::Node::getName() const {
+    return !name_.empty() ? name_ : "(unnamed)";
+}
+
+inline bool ConnectionIntrospector::Node::operator==(const Node& other) const {
+    return (endpoint_ == other.endpoint_);
+}
+
+inline bool ConnectionIntrospector::Node::operator<(const Node& other) const {
+    return (endpoint_ < other.endpoint_);
+}
+
+inline ConnectionIntrospector::Node::const_iterator ConnectionIntrospector::Node::begin() const {
+    return connections_.begin();
+}
+
+inline ConnectionIntrospector::Node::const_iterator ConnectionIntrospector::Node::end() const {
+    return connections_.end();
+}
+
+ConnectionIntrospector::PortNode::PortNode(const base::PortInterface* port)
+    : Node(port->getEndpoint(), port->getQualifiedName()), port_(port) {
+    const RTT::base::InputPortInterface *input = dynamic_cast<const RTT::base::InputPortInterface *>(port);
+    const RTT::base::OutputPortInterface *output = dynamic_cast<const RTT::base::OutputPortInterface *>(port);
+    if (input) {
+        direction_ = Input;
+    } else if (output) {
+        direction_ = Output;
     }
+}
 
-    bool ConnectionIntrospector::PortQualifier::operator==(
-            const PortQualifier& other) const {
-        // For simplicity, remote ports are always different for now.
-        return !this->is_remote && !other.is_remote &&
-                (this->owner_name == other.owner_name) &&
-                (this->port_name == other.port_name);
+inline const base::PortInterface *ConnectionIntrospector::PortNode::getPort() const {
+    return port_;
+}
+
+std::string ConnectionIntrospector::PortNode::getPortType() const {
+    switch(getDirection()) {
+        case Input:  return "In";
+        case Output: return "Out";
+        default:     return "";
     }
+}
 
-    bool ConnectionIntrospector::PortQualifier::operator<(
-            const PortQualifier& other) const {
-        if (owner_name < other.owner_name) return true;
-        if (owner_name > other.owner_name) return false;
-        return port_name < other.port_name;
+inline bool ConnectionIntrospector::PortNode::isRemote() const {
+    return !(port_->isLocal());
+}
+
+ConnectionIntrospector::Connection::Connection(const ConnectionIntrospector::NodePtr &from,
+                                               const ConnectionIntrospector::NodePtr &to,
+                                               const ConnectionManager::ChannelDescriptor &from_descriptor)
+    : from_(from, from_descriptor), to_(to, ConnectionManager::ChannelDescriptor()) {
+    if (from->getDirection() == Node::Input) {
+        assert(to->getDirection() != Node::Input);
+        is_forward_ = false;
+    } else if (from->getDirection() == Node::Output) {
+        assert(to->getDirection() != Node::Output);
+        is_forward_ = true;
+    } else if (to->getDirection() == Node::Input) {
+        is_forward_ = true;
+    } else if (to->getDirection() == Node::Output) {
+        is_forward_ = false;
+    } else {
+        assert(false && "Direction of data flow is not well-defined");
+        is_forward_ = true;
     }
+}
 
-    ConnectionIntrospector::ConnectionIntrospector(
-            const ConnectionManager::ChannelDescriptor& descriptor,
-            const PortQualifier& port,
-            bool forward, int curr_depth) {
-        is_forward = forward;
-        connection_id = descriptor.get<0>();
-        connection_policy = descriptor.get<2>();
-        if (is_forward) {
-            in_port = PortQualifier(
-                        descriptor.get<1>()->getOutputEndPoint()->getPort());
-            out_port = port;
-        } else {
-            in_port = port;
-            out_port = PortQualifier(
-                        descriptor.get<1>()->getInputEndPoint()->getPort());
-        }
-        depth = curr_depth;
+ConnectionIntrospector::Connection::~Connection() {}
+
+inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::from() const {
+    return from_.first.lock();
+}
+
+inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::to() const {
+    return to_.first.lock();
+}
+
+inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::getOutput() const {
+    return is_forward_ ? from() : to();
+}
+
+inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::getInput() const {
+    return is_forward_ ? to() : to();
+}
+
+inline bool ConnectionIntrospector::Connection::isForward() const {
+    return is_forward_;
+}
+
+ConnectionIntrospector::ConnectionIntrospector(const base::PortInterface* port)
+    : depth_(0)
+{
+    add(port);
+}
+
+ConnectionIntrospector::ConnectionIntrospector(const DataFlowInterface* interface)
+    : depth_(0)
+{
+    add(interface);
+}
+
+ConnectionIntrospector::ConnectionIntrospector(const TaskContext* tc)
+    : depth_(0)
+{
+    add(tc);
+}
+
+void ConnectionIntrospector::add(const base::PortInterface* port)
+{
+    NodePtr node(new PortNode(port));
+    start_nodes_.push_back(NodePtr(new PortNode(port)));
+}
+
+void ConnectionIntrospector::add(const DataFlowInterface *interface) {
+    DataFlowInterface::PortNames ports = interface->getPortNames();
+    for(DataFlowInterface::PortNames::const_iterator it = ports.begin();
+        it != ports.end(); ++it) {
+        NodePtr node(new PortNode(interface->getPort(*it)));
+        start_nodes_.push_back(node);
     }
+}
 
-    ConnectionIntrospector::ConnectionIntrospector(
-            const base::PortInterface* port_ptr) {
-        PortQualifier port(port_ptr);
-        if (port.is_forward) {
-            out_port = port;
-        } else {
-            in_port = port;
-        }
-        // This is the fake "incoming" port connection, so forward is the
-        // opposite of the port value.
-        is_forward = !port.is_forward;
-        depth = 0;
+void ConnectionIntrospector::add(const TaskContext* tc) {
+    return add(tc->ports());
+}
+
+void ConnectionIntrospector::reset() {
+    nodes_.clear();
+    for(Nodes::iterator it = nodes_.begin(); it != nodes_.end(); ++it) {
+        (*it)->connections_.clear();
     }
+    depth_ = 0;
+}
 
-    ConnectionIntrospector::ConnectionIntrospector(const TaskContext* tc) {
-        if (!tc) {
-            in_port.is_remote = true;
-            in_port.owner_name = "{EMPTY_COMPONENT}";
-            is_forward = true;
-            depth = -1;
-            return;
-        }
-        in_port.owner_name = tc->getName();
-        is_forward = true;
-        depth = -1;
-        if (tc->ports() && !(tc->ports()->getPortNames().empty())) {
-            DataFlowInterface::PortNames port_names = tc->ports()->getPortNames();
-            for (size_t j = 0; j < port_names.size(); ++j) {
-                const std::string& port_name = port_names.at(j);
-                base::PortInterface* port_ptr = tc->getPort(port_name);
-                ConnectionIntrospector ci(port_ptr);
-                sub_connections.push_back(ci);
-            }
-            in_port.is_remote = false;
-        } else {
-            in_port.is_remote = true;
-        }
-    }
+void ConnectionIntrospector::createGraph(int depth) {
+    createGraphInternal(depth, start_nodes_);
+}
 
-    bool ConnectionIntrospector::operator==(const ConnectionIntrospector& other)
-            const {
-        return this->in_port == other.in_port &&
-                this->out_port == other.out_port;
-    }
+void ConnectionIntrospector::createGraphInternal(int remaining_depth, const Nodes& to_visit) {
+    if (remaining_depth < 1) remaining_depth = 1;
+    --remaining_depth;
+    Nodes next_visit;
 
-    bool ConnectionIntrospector::operator<(const ConnectionIntrospector& other)
-            const {
-        if (out_port < other.out_port) return true;
-        if (other.out_port < out_port) return false;
-        return in_port < other.in_port;
-    }
+    for(Nodes::const_iterator node_it = to_visit.begin(); node_it != to_visit.end(); ++node_it) {
+        const NodePtr &node = *node_it;
 
-    void ConnectionIntrospector::createGraph(int depth) {
-        std::list<ConnectionIntrospector*> to_visit;
-        if (sub_connections.empty()) {
-            to_visit.push_back(this);
-        } else {
-            for (std::list< ConnectionIntrospector >::iterator
-                    it = this->sub_connections.begin();
-                    it != this->sub_connections.end(); ++it) {
-                to_visit.push_back(&(*it));
-            }
-        }
-        std::set<ConnectionIntrospector> visited;
-        createGraph(depth, to_visit, visited);
-    }
+        // If the node represents a port, iterate over all connections:
+        PortNode *port_node = dynamic_cast<PortNode *>(node.get());
+        if (port_node) {
+            ConnectionManager::Connections connections = port_node->getPort()->getManager()->getConnections();
+            for(ConnectionManager::Connections::const_iterator con_it = connections.begin();
+                con_it != connections.end(); ++con_it) {
+                const ConnectionManager::ChannelDescriptor &descriptor = *con_it;
+//                const ConnID *conn_id = descriptor.get<0>().get();
+//                const base::PortInterface *other_port = conn_id->getPort();
+                const base::PortInterface *other_port = descriptor.get<1>()->getPort();
+                NodePtr other;
+                if (other_port) {
+                    other.reset( new PortNode(other_port) );
+                } else {
+                    other.reset( new Node(descriptor.get<1>().get()) );
+                }
 
-    void ConnectionIntrospector::createGraph(
-            int depth,
-            std::list<ConnectionIntrospector*>& to_visit,
-            std::set<ConnectionIntrospector>& visited) {
-        if (depth < 1) {depth = 1;}
+                // Check if the other node is already known
+                ConnectionPtr connection;
+                NodePtr found = findNode(*other);
+                if (found) {
+                    // replace other pointer with found node
+                    other = found;
 
-        while (!to_visit.empty()) {
-            ConnectionIntrospector& node(*(to_visit.front()));
-            to_visit.pop_front();
-            int curr_depth = node.depth;
-            if (curr_depth >= depth) {
-                continue;
-            }
-            PortQualifier& port = node.is_forward ? node.in_port : node.out_port;
+                    // try to find matching connection in other where to == node
+                    connection = findConnectionTo(other->connections_, *node);
+                    if (connection) {
+                        // complete descriptor (to part should be empty)
+                        assert(connection->to_.second.get<0>() == 0);
+                        assert(connection->to_.second.get<1>() == 0);
+                        assert(connection->from_.second.get<1>() == node->getEndpoint());
+                        connection->to_.second = descriptor;
+                    }
 
-            // Would be false for remote ports.
-            if (!port.is_remote) {
-                std::list<ConnectionIntrospector> ci_list;
-                if (!node.sub_connections.empty()) {
-                    // Inspecting an already created list, append extra connections.
-                    ci_list.insert(ci_list.end(), node.sub_connections.begin(),
-                                   node.sub_connections.end());
-                    node.sub_connections.clear();
-                } else if (port.port_ptr && port.port_ptr->getManager()) {
-                    // Perform conversion from ChannelDescriptor.
-                    std::list<ConnectionManager::ChannelDescriptor>
-                            connections = port.port_ptr->getManager()->getConnections();
-                    for (std::list<ConnectionManager::ChannelDescriptor>::const_iterator
-                            it = connections.begin(); it != connections.end(); ++it) {
-                        ci_list.push_back(ConnectionIntrospector(
-                                *it, port, !node.is_forward, curr_depth + 1));
+                } else {
+                    nodes_.push_back(other);
+                    if (remaining_depth > 0) {
+                        next_visit.push_back(other);
                     }
                 }
-                // Check whether connections have already been visited,
-                // otherwise add them to the to_visit list.
-                for (std::list<ConnectionIntrospector>::const_iterator
-                        it = ci_list.begin(); it != ci_list.end(); ++it) {
-                    if (visited.count(*it)) {
-                        continue;
-                    }
-                    visited.insert(*it);
-                    node.sub_connections.push_back(*it);
-                    to_visit.push_back(&(node.sub_connections.back()));
+
+                // Create new connection if none has been found
+                if (!connection.get()) {
+                    connection.reset(new Connection(node, other, descriptor));
                 }
-            } else {
-                if (node.connection_id) {
-                    port.port_name = node.connection_id->getName();
-                }
+                node->connections_.push_back(connection);
             }
         }
     }
 
-    std::ostream& operator<<(
-            std::ostream& os,
-            const ConnectionIntrospector::PortQualifier& pq) {
-        os << pq.owner_name << "." << pq.port_name;
-        return os;
+    if (!next_visit.empty()) {
+        createGraphInternal(remaining_depth, next_visit);
     }
+}
 
-    std::ostream& ConnectionIntrospector::printIndented(std::ostream& os,
-            int i) const {
-        const int currIndent = 4 * this->depth + i;
-        if (this->depth == -1) {
-            // For depth -1, only log the component name.
-            os << std::string(i, ' ') << this->in_port.owner_name
-               << " COMPONENT\n";
-        } else if (this->depth == 0) {
-            // For depth 0, only log the port.
-            std::string connection_summary;
-            const int connection_nr = this->sub_connections.size();
-            switch (connection_nr) {
-            case 0:
-                connection_summary = "No";
-                break;
-            case 1:
-                connection_summary = "Single";
-                break;
-            default:
-                connection_summary = "Multiple";
-                break;
-            }
-            os << std::string(currIndent, ' ')
-               << (this->is_forward ? " IN " : " OUT ")
-               << (this->is_forward ? this->in_port
-                                         : this->out_port)
-               << " with " << connection_summary << " connection(s) (#"
-               << connection_nr << ")" << ":\n";
-        } else if (this->depth > 0) {
-            // Positive depth, log the full connection information.
-            os << std::string(currIndent, ' ')
-               << (this->is_forward ? " -> IN " : " <- OUT ")
-               << ((this->is_forward ? this->in_port
-                                         : this->out_port).is_remote ?
-                      "(remote) " : "")
-               << (this->is_forward ? this->in_port
-                                         : this->out_port)
-               << " : (" << this->connection_policy << ")\n";
-        }
-        for (std::list< ConnectionIntrospector >::const_iterator
-                it = this->sub_connections.begin();
-             it != this->sub_connections.end(); ++it) {
-            os << *it;
-        }
-        return os;
+ConnectionIntrospector::NodePtr ConnectionIntrospector::findNode(const Node &node) const {
+    Nodes::const_iterator it;
+    for(it = start_nodes_.begin(); it != start_nodes_.end(); ++it) {
+        if (**it == node) return *it;
     }
+    for(it = nodes_.begin(); it != nodes_.end(); ++it) {
+        if (**it == node) return *it;
+    }
+    return NodePtr();
+}
 
-    boost::function<std::ostream&(std::ostream&)>
-    ConnectionIntrospector::indent(int i) const {
-        return boost::bind(&ConnectionIntrospector::printIndented, this, _1, i);
+ConnectionIntrospector::ConnectionPtr ConnectionIntrospector::findConnectionTo(const Connections &connections, const Node &node) const {
+    Connections::const_iterator it;
+    for(it = connections.begin(); it != connections.end(); ++it) {
+        if (*((*it)->to()) == node) return *it;
     }
+    return ConnectionPtr();
+}
 
-    std::ostream& operator<<(
-            std::ostream& os,
-            const ConnectionIntrospector& descriptor) {
-        return descriptor.indent(0)(os);
-    }
+//static std::ostream& ConnectionIntrospector::printIndented(std::ostream& os,
+//        int i) const {
+//    const int currIndent = 4 * this->depth + i;
+//    if (this->depth == -1) {
+//        // For depth -1, only log the component name.
+//        os << std::string(i, ' ') << this->in_port.owner_name
+//           << " COMPONENT\n";
+//    } else if (this->depth == 0) {
+//        // For depth 0, only log the port.
+//        std::string connection_summary;
+//        const int connection_nr = this->sub_connections.size();
+//        switch (connection_nr) {
+//        case 0:
+//            connection_summary = "No";
+//            break;
+//        case 1:
+//            connection_summary = "Single";
+//            break;
+//        default:
+//            connection_summary = "Multiple";
+//            break;
+//        }
+//        os << std::string(currIndent, ' ')
+//           << (this->is_forward ? " IN " : " OUT ")
+//           << (this->is_forward ? this->in_port
+//                                     : this->out_port)
+//           << " with " << connection_summary << " connection(s) (#"
+//           << connection_nr << ")" << ":\n";
+//    } else if (this->depth > 0) {
+//        // Positive depth, log the full connection information.
+//        os << std::string(currIndent, ' ')
+//           << (this->is_forward ? " -> IN " : " <- OUT ")
+//           << ((this->is_forward ? this->in_port
+//                                     : this->out_port).is_remote ?
+//                  "(remote) " : "")
+//           << (this->is_forward ? this->in_port
+//                                     : this->out_port)
+//           << " : (" << this->connection_policy << ")\n";
+//    }
+//    for (std::list< ConnectionIntrospector >::const_iterator
+//            it = this->sub_connections.begin();
+//         it != this->sub_connections.end(); ++it) {
+//        os << *it;
+//    }
+//    return os;
+//}
+
+//boost::function<std::ostream&(std::ostream&)>
+//ConnectionIntrospector::indent(int i) const {
+//    return boost::bind(&ConnectionIntrospector::printIndented, this, _1, i);
+//}
+
+std::ostream& operator<<(
+        std::ostream& os,
+        const ConnectionIntrospector& descriptor) {
+//    return descriptor.indent(0)(os);
+//    return printTo(descriptor.start_nodes_, os);
+    return os;
+}
 
 }  // namespace internal
 }  // namespace RTT

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -1,0 +1,134 @@
+#include "ConnectionIntrospector.hpp"
+
+namespace RTT {
+namespace internal {
+
+    ConnectionIntrospector::ConnectionIntrospector(
+            const ConnectionManager::ChannelDescriptor& descriptor,
+            bool forward, int curr_depth) {
+        is_forward = forward;
+        connection_id = descriptor.get<0>();
+        connection_policy = descriptor.get<2>();
+        in_port = PortQualifier(
+                    descriptor.get<1>()->getOutputEndPoint()->getPort());
+        out_port = PortQualifier(
+                    descriptor.get<1>()->getInputEndPoint()->getPort());
+        depth = curr_depth;
+    }
+    ConnectionIntrospector::ConnectionIntrospector(
+            const base::PortInterface* port) {
+        PortQualifier port_(port);
+        if (port_.is_forward) {
+            out_port = port_;
+        } else {
+            in_port = port_;
+        }
+        // This is the fake "incoming" port connection, so forward is the
+        // opposite of the port value.
+        is_forward = !port_.is_forward;
+        depth = 0;
+    }
+
+    bool ConnectionIntrospector::operator==(const ConnectionIntrospector& other)
+            const {
+        return this->in_port == other.in_port &&
+                this->out_port == other.out_port;
+    }
+
+    bool ConnectionIntrospector::operator<(const ConnectionIntrospector& other)
+            const {
+        if (out_port < other.out_port) return true;
+        if (other.out_port < out_port) return false;
+        return in_port < other.in_port;
+    }
+
+    void ConnectionIntrospector::createGraph(int depth) {
+        std::list<ConnectionIntrospector*> to_visit;
+        to_visit.push_back(this);
+        std::set<ConnectionIntrospector> visited;
+        createGraph(depth, to_visit, visited);
+    }
+
+    void ConnectionIntrospector::createGraph(
+            int depth,
+            std::list<ConnectionIntrospector*>& to_visit,
+            std::set<ConnectionIntrospector>& visited) {
+        if (depth < 1) {depth = 1;}
+
+        while (!to_visit.empty()) {
+            ConnectionIntrospector& node(*(to_visit.front()));
+            to_visit.pop_front();
+            int curr_depth = node.depth;
+            if (curr_depth >= depth) {
+                continue;
+            }
+            std::list<ConnectionIntrospector>& connection_list = node.sub_connections;
+            PortQualifier& port = node.is_forward ? node.in_port : node.out_port;
+
+            // Would be undefined for remote ports.
+            if (!port.is_remote) {
+                std::list<ConnectionManager::ChannelDescriptor>
+                        connections = port.port_ptr->getManager()->getConnections();
+                for (std::list<ConnectionManager::ChannelDescriptor>::const_iterator it = connections.begin();
+                     it != connections.end(); ++it) {
+                    // Push back one connection, and add the node to the "to_visit" list.
+                    ConnectionIntrospector
+                            conn_descriptor(*it, !node.is_forward, curr_depth + 1);
+                    if (visited.count(conn_descriptor)) {
+                        continue;
+                    }
+                    visited.insert(conn_descriptor);
+                    connection_list.push_back(conn_descriptor);
+                    to_visit.push_back(&(connection_list.back()));
+                }
+            } else {
+                port.port_name = node.connection_id->portName();
+            }
+        }
+    }
+
+    std::ostream& operator<<(
+            std::ostream& os,
+            const ConnectionIntrospector::PortQualifier& pq) {
+        os << pq.owner_name << "." << pq.port_name;
+        return os;
+    }
+
+    std::ostream& ConnectionIntrospector::printIndented(std::ostream& os,
+            int i) const {
+        const int currIndent = 4 * this->depth + i;
+        // For the first level (entry-point), only log the port.
+        if (this->depth == 0) {
+            os << std::string(currIndent, ' ')
+               << (this->is_forward ? " IN " : " OUT ")
+               << (this->is_forward ? this->in_port
+                                         : this->out_port) << ":\n";
+        } else {
+            os << std::string(currIndent, ' ')
+               << (this->is_forward ? " -> IN " : " <- OUT ")
+               << (this->is_forward ? this->in_port
+                                         : this->out_port)
+               << " : (" << this->connection_id->typeString()
+               << " = " << this->connection_policy << ")\n";
+        }
+        for (std::list< ConnectionIntrospector >::const_iterator
+                it = this->sub_connections.begin();
+             it != this->sub_connections.end(); ++it) {
+            os << *it;
+        }
+        return os;
+    }
+
+    boost::function<std::ostream&(std::ostream&)>
+    ConnectionIntrospector::indent(int i) const {
+        return boost::bind(&ConnectionIntrospector::printIndented, this, _1, i);
+    }
+
+    std::ostream& operator<<(
+            std::ostream& os,
+            const ConnectionIntrospector& descriptor) {
+        return descriptor.indent(0)(os);
+    }
+
+}  // namespace internal
+}  // namespace RTT

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -105,7 +105,7 @@ inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::getOu
 }
 
 inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::getInput() const {
-    return is_forward_ ? to() : to();
+    return is_forward_ ? to() : from();
 }
 
 inline bool ConnectionIntrospector::Connection::isForward() const {

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -3,6 +3,7 @@
 #include "../Port.hpp"
 #include "../TaskContext.hpp"
 
+#include <boost/lexical_cast.hpp>
 #include <cassert>
 
 namespace RTT {
@@ -258,7 +259,7 @@ std::string ConnectionIntrospector::Node::getConnectionSummary() const {
     }
 
     return (" with " + connection_summary + " connection(s) (#"
-            + std::to_string(connection_nr) + ")");
+            + boost::lexical_cast<std::string>(connection_nr) + ")");
 }
 
 std::ostream& ConnectionIntrospector::Node::printIndented(
@@ -320,7 +321,8 @@ std::ostream& operator<<(
          node != descriptor.start_nodes_.end(); ++node) {
         (*node)->printIndented(
                     os, descriptor.depth_, 0,
-                    ConnectionIntrospector::ConnectionPtr(), {}) << "\n";
+                    ConnectionIntrospector::ConnectionPtr(),
+                    ConnectionIntrospector::Connections()) << "\n";
     }
 
     return os;

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -1,4 +1,42 @@
+/***************************************************************************
+  tag: Intermodalics BVBA  Sat Jan 27 00:13:48 CET 2018  ConnectionIntrospector.cpp
+
+                        ConnectionIntrospector.cpp -  description
+                           -------------------
+    begin                : Sat January 27 2018
+    copyright            : (C) 2018 Intermodalics BVBA
+    email                : info@intermodalics.eu
+
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU General Public                   *
+ *   License as published by the Free Software Foundation;                 *
+ *   version 2 of the License.                                             *
+ *                                                                         *
+ *   As a special exception, you may use this file as part of a free       *
+ *   software library without restriction.  Specifically, if other files   *
+ *   instantiate templates or use macros or inline functions from this     *
+ *   file, or you compile this file and link it with other files to        *
+ *   produce an executable, this file does not by itself cause the         *
+ *   resulting executable to be covered by the GNU General Public          *
+ *   License.  This exception does not however invalidate any other        *
+ *   reasons why the executable file might be covered by the GNU General   *
+ *   Public License.                                                       *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public             *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "ConnectionIntrospector.hpp"
+#include "SharedConnection.hpp"
 
 #include "../Port.hpp"
 #include "../TaskContext.hpp"
@@ -8,44 +46,58 @@
 
 namespace RTT {
 
-// forward declaration of corba::RemoteConnID
-namespace corba {
-   class RemoteConnID;
-}
-
 namespace internal {
 
-ConnectionIntrospector::Node::Node(base::ChannelElementBase *endpoint, const std::string &name)
-    : direction_(Unspecified), endpoint_(endpoint), name_(name) {}
-
-ConnectionIntrospector::Node::~Node() {}
-
-inline base::ChannelElementBase::shared_ptr ConnectionIntrospector::Node::getEndpoint() const {
-    return endpoint_;
+ConnectionIntrospector::Node::Node(const std::string &name)
+    : direction_(Unspecified), name_(name)
+{
 }
 
-inline std::string ConnectionIntrospector::Node::getName() const {
-    return !name_.empty() ? name_ : "(unnamed)";
+ConnectionIntrospector::Node::~Node()
+{
 }
 
-inline bool ConnectionIntrospector::Node::operator==(const Node& other) const {
-    return (endpoint_ == other.endpoint_);
+inline const base::PortInterface *ConnectionIntrospector::Node::getPort() const
+{
+    return 0;
 }
 
-inline bool ConnectionIntrospector::Node::operator<(const Node& other) const {
-    return (endpoint_ < other.endpoint_);
+inline base::ChannelElementBase::shared_ptr ConnectionIntrospector::Node::getEndpoint() const
+{
+    if (getPort()) {
+        return getPort()->getEndpoint();
+    }
+    return 0;
 }
 
-inline ConnectionIntrospector::Node::const_iterator ConnectionIntrospector::Node::begin() const {
+inline std::string ConnectionIntrospector::Node::getName() const
+{
+    return !name_.empty() ? name_ : "(unknown)";
+}
+
+inline bool ConnectionIntrospector::Node::operator==(const Node& other) const
+{
+    return (this->getEndpoint() == other.getEndpoint());
+}
+
+inline bool ConnectionIntrospector::Node::operator<(const Node& other) const
+{
+    return (this->getEndpoint() < other.getEndpoint());
+}
+
+inline ConnectionIntrospector::Node::const_iterator ConnectionIntrospector::Node::begin() const
+{
     return connections_.begin();
 }
 
-inline ConnectionIntrospector::Node::const_iterator ConnectionIntrospector::Node::end() const {
+inline ConnectionIntrospector::Node::const_iterator ConnectionIntrospector::Node::end() const
+{
     return connections_.end();
 }
 
 ConnectionIntrospector::PortNode::PortNode(const base::PortInterface* port)
-    : Node(port->getEndpoint(), port->getQualifiedName()), port_(port) {
+    : Node(port->getQualifiedName()), port_(port)
+{
     const RTT::base::InputPortInterface *input = dynamic_cast<const RTT::base::InputPortInterface *>(port);
     const RTT::base::OutputPortInterface *output = dynamic_cast<const RTT::base::OutputPortInterface *>(port);
     if (input) {
@@ -55,26 +107,29 @@ ConnectionIntrospector::PortNode::PortNode(const base::PortInterface* port)
     }
 }
 
-inline const base::PortInterface *ConnectionIntrospector::PortNode::getPort() const {
-    return port_;
-}
-
-std::string ConnectionIntrospector::PortNode::getPortType() const {
-    switch(getDirection()) {
-        case Input:  return "In";
-        case Output: return "Out";
-        default:     return "";
-    }
-}
-
-inline bool ConnectionIntrospector::PortNode::isRemote() const {
+inline bool ConnectionIntrospector::PortNode::isRemote() const
+{
     return !(port_->isLocal());
+}
+
+ConnectionIntrospector::RemoteNode::RemoteNode(const base::ChannelElementBase::shared_ptr &endpoint,
+                                               Node::Direction direction,
+                                               const std::string &name)
+    : Node(name), endpoint_(endpoint)
+{
+    direction_ = direction;
+}
+
+ConnectionIntrospector::SharedConnectionNode::SharedConnectionNode(const internal::SharedConnectionBase::shared_ptr &shared_connection)
+    : Node(shared_connection->getName()), shared_connection_(shared_connection)
+{
 }
 
 ConnectionIntrospector::Connection::Connection(const ConnectionIntrospector::NodePtr &from,
                                                const ConnectionIntrospector::NodePtr &to,
-                                               const ConnectionManager::ChannelDescriptor &from_descriptor)
-    : from_(from, from_descriptor), to_(to, ConnectionManager::ChannelDescriptor()) {
+                                               const ConnPolicy &policy)
+    : from_(from), to_(to), policy_(policy)
+{
     if (from->getDirection() == Node::Input) {
         assert(to->getDirection() != Node::Input);
         is_forward_ = false;
@@ -93,14 +148,6 @@ ConnectionIntrospector::Connection::Connection(const ConnectionIntrospector::Nod
 
 ConnectionIntrospector::Connection::~Connection() {}
 
-inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::from() const {
-    return from_.first.lock();
-}
-
-inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::to() const {
-    return to_.first.lock();
-}
-
 inline ConnectionIntrospector::NodePtr ConnectionIntrospector::Connection::getOutput() const {
     return is_forward_ ? from() : to();
 }
@@ -114,19 +161,16 @@ inline bool ConnectionIntrospector::Connection::isForward() const {
 }
 
 ConnectionIntrospector::ConnectionIntrospector(const base::PortInterface* port)
-    : depth_(0)
 {
     add(port);
 }
 
 ConnectionIntrospector::ConnectionIntrospector(const DataFlowInterface* interface)
-    : depth_(0)
 {
     add(interface);
 }
 
 ConnectionIntrospector::ConnectionIntrospector(const TaskContext* tc)
-    : depth_(0)
 {
     add(tc);
 }
@@ -155,17 +199,14 @@ void ConnectionIntrospector::reset() {
     for(Nodes::iterator it = nodes_.begin(); it != nodes_.end(); ++it) {
         (*it)->connections_.clear();
     }
-    depth_ = 0;
 }
 
 void ConnectionIntrospector::createGraph(int depth) {
-    depth_ = depth;
     createGraphInternal(depth, start_nodes_);
 }
 
 void ConnectionIntrospector::createGraphInternal(int remaining_depth, const Nodes& to_visit) {
-    if (remaining_depth < 1) remaining_depth = 1;
-    --remaining_depth;
+    if (remaining_depth <= 0) return;
     Nodes next_visit;
 
     for(Nodes::const_iterator node_it = to_visit.begin(); node_it != to_visit.end(); ++node_it) {
@@ -178,50 +219,120 @@ void ConnectionIntrospector::createGraphInternal(int remaining_depth, const Node
             for(ConnectionManager::Connections::const_iterator con_it = connections.begin();
                 con_it != connections.end(); ++con_it) {
                 const ConnectionManager::ChannelDescriptor &descriptor = *con_it;
-                const base::PortInterface *other_port = descriptor.get<1>()->getPort();
-                NodePtr other;
-                if (other_port) {
-                    other.reset( new PortNode(other_port) );
+                base::ChannelElementBase::shared_ptr endpoint;
+                Node::Direction direction = Node::Unspecified;
+                if (port_node->getDirection() == Node::Output) {
+                    endpoint = descriptor.get<1>()->getOutputEndPoint();
+                    direction = Node::Input;
+                } else if (port_node->getDirection() == Node::Input) {
+                    endpoint = descriptor.get<1>()->getInputEndPoint();
+                    direction = Node::Output;
                 } else {
-                    other.reset( new Node(descriptor.get<1>().get(), (descriptor.get<0>() ? descriptor.get<0>()->getName() : "")) );
+                    endpoint = descriptor.get<1>();
                 }
 
-                // Check if the other node is already known
+                NodePtr other;
                 ConnectionPtr connection;
-                NodePtr found = findNode(*other);
-                if (found) {
-                    // replace other pointer with found node
-                    other = found;
+                bool found = findOrCreateNeighbor(node, endpoint, direction,
+                                                  descriptor.get<0>()->getName(),
+                                                  descriptor.get<2>(),
+                                                  other, connection);
 
-                    // try to find matching connection in other where to == node
-                    connection = findConnectionTo(other->connections_, *node);
-                    if (connection) {
-                        // complete descriptor (to part should be empty)
-                        assert(connection->to_.second.get<0>() == 0);
-                        assert(connection->to_.second.get<1>() == 0);
-                        assert(connection->from_.second.get<1>() == node->getEndpoint());
-                        connection->to_.second = descriptor;
-                    }
-
-                } else {
-                    nodes_.push_back(other);
-                    if (remaining_depth > 0) {
+                if (!found) { // new node
+                    if (other->isSharedConnection()) {
+                        // immediately expand all connected nodes without decrementing remaining_depth
+                        // (traversing a shared connection counts as a single hop)
+                        createGraphInternal(remaining_depth, Nodes(1, other));
+                    } else if (remaining_depth > 1) {
                         next_visit.push_back(other);
                     }
                 }
+            }
+        }
 
-                // Create new connection if none has been found
-                if (!connection.get()) {
-                    connection.reset(new Connection(node, other, descriptor));
+        SharedConnectionNode *shared_connection_node = dynamic_cast<SharedConnectionNode *>(node.get());
+        if (shared_connection_node) {
+            const internal::SharedConnectionBase::shared_ptr &shared_connection
+                = shared_connection_node->getSharedConnection();
+
+            base::MultipleOutputsChannelElementBase::Outputs outputs = shared_connection->getOutputs();
+            for(base::MultipleOutputsChannelElementBase::Outputs::const_iterator output = outputs.begin();
+                output != outputs.end(); ++output) {
+                base::ChannelElementBase::shared_ptr endpoint = output->channel->getOutputEndPoint();
+                NodePtr other;
+                ConnectionPtr connection;
+                bool found = findOrCreateNeighbor(node, endpoint,  Node::Output,
+                                                  std::string(),
+                                                  *shared_connection->getConnPolicy(),
+                                                  other, connection);
+                if (!found && remaining_depth > 1) {
+                    next_visit.push_back(other);
                 }
-                node->connections_.push_back(connection);
+            }
+
+            base::MultipleInputsChannelElementBase::Inputs inputs = shared_connection->getInputs();
+            for(base::MultipleInputsChannelElementBase::Inputs::const_iterator input = inputs.begin();
+                input != inputs.end(); ++input) {
+                base::ChannelElementBase::shared_ptr endpoint = (*input)->getInputEndPoint();
+                NodePtr other;
+                ConnectionPtr connection;
+                bool found = findOrCreateNeighbor(node, endpoint,  Node::Input,
+                                                  std::string(),
+                                                  *shared_connection->getConnPolicy(),
+                                                  other, connection);
+                if (!found && remaining_depth > 1) {
+                    next_visit.push_back(other);
+                }
             }
         }
     }
 
     if (!next_visit.empty()) {
-        createGraphInternal(remaining_depth, next_visit);
+        createGraphInternal(remaining_depth - 1, next_visit);
     }
+}
+
+bool ConnectionIntrospector::findOrCreateNeighbor(
+        const NodePtr &node,
+        const base::ChannelElementBase::shared_ptr &endpoint,
+        ConnectionIntrospector::Node::Direction direction,
+        const std::string &name, const ConnPolicy &policy,
+        NodePtr &other, ConnectionPtr &connection) {
+    // a port?
+    const base::PortInterface *port = endpoint->getPort();
+    if (port) {
+        other.reset( new PortNode(port) );
+    } else {
+        // a shared connection?
+        internal::SharedConnectionBase::shared_ptr shared_connection
+            = dynamic_cast<RTT::internal::SharedConnectionBase *>(endpoint.get());
+        if (shared_connection) {
+            other.reset( new SharedConnectionNode(shared_connection) );
+        } else {
+            // or a remote connection?
+            other.reset( new RemoteNode(endpoint, direction, name) );
+        }
+    }
+
+    // Check if the node is already known
+    NodePtr found = findNode(*other);
+    if (found) {
+        // replace node pointer with found node
+        other = found;
+
+        // try to find matching connection from other to node
+        connection = findConnectionTo(other->connections_, *node);
+    } else {
+        nodes_.push_back(other);
+    }
+
+    // Create new connection if none has been found
+    if (!connection) {
+        connection.reset(new Connection(node, other, policy));
+    }
+    node->connections_.push_back(connection);
+
+    return found;
 }
 
 ConnectionIntrospector::NodePtr ConnectionIntrospector::findNode(const Node &node) const {
@@ -244,68 +355,72 @@ ConnectionIntrospector::ConnectionPtr ConnectionIntrospector::findConnectionTo(c
 }
 
 std::string ConnectionIntrospector::Node::getConnectionSummary() const {
-    std::string connection_summary;
-    const int connection_nr = this->connections_.size();
+    const std::size_t connection_nr = this->connections_.size();
     switch (connection_nr) {
     case 0:
-        connection_summary = "no";
-        break;
+        return " has no connections.";
     case 1:
-        connection_summary = "single";
-        break;
+        return " has a single connection:";
     default:
-        connection_summary = "multiple";
-        break;
+        return " has multiple connections (#"
+               + boost::lexical_cast<std::string>(connection_nr) + "):";
     }
-
-    return (" with " + connection_summary + " connection(s) (#"
-            + boost::lexical_cast<std::string>(connection_nr) + ")");
 }
 
 std::ostream& ConnectionIntrospector::Node::printIndented(
-        std::ostream& os, int depth, int indent_lvl,
-        const ConnectionPtr incoming_connection,
-        Connections printed_connections) const {
-    if (indent_lvl > depth) return os;
+        std::ostream& os, int indent_lvl,
+        const ConnectionPtr &incoming_connection,
+        ConnectionSet &printed_connections) const {
 
-    if (std::find(printed_connections.begin(), printed_connections.end(),
-                  incoming_connection) != printed_connections.end()) {
+    // Never traverse the same connections twice
+    if (printed_connections.find(incoming_connection.get()) != printed_connections.end()) {
         return os;
     } else if (incoming_connection.get()){
-        printed_connections.push_back(incoming_connection);
+        printed_connections.insert(incoming_connection.get());
     }
 
-    const std::string port_type = "[" +
-            (this->isPort()
-                ? dynamic_cast<const ConnectionIntrospector::PortNode *>(this)->getPortType()
-                : "NOT")
-            + " port] ";
-    const std::string is_remote =
-            this->isRemote() ? "[REMOTE: " + this->endpoint_->getElementName() + "] "
-                             : "";
-
-    const std::string connection_summary =
-            (indent_lvl == 0 ? this->getConnectionSummary() : "");
-
-    ConnectionPtr connection = incoming_connection;
-    std::ostringstream connection_str;
-    if (connection.get()) {
-        assert(connection->from().get());
-        connection_str << " [" << connection->from_.second.get<2>() << "]";
+    const std::string indent(2 * indent_lvl, ' ');
+    os << indent;
+    if (incoming_connection) {
+        if (( incoming_connection->isForward() && (incoming_connection->to().get() == this)) ||
+            (!incoming_connection->isForward() && (incoming_connection->from().get() == this))) {
+            os << "--> ";
+        } else {
+            os << "<-- ";
+        }
     }
-
-    const int currIndent = 4 * indent_lvl;
-    os << std::string(currIndent, ' ')
-       << port_type << is_remote << this->getName() << connection_summary
-       << connection_str.str() << "\n";
+    switch(getDirection()) {
+    case Input:
+        os << " In ";
+        break;
+    case Output:
+        os << "Out ";
+        break;
+    default:
+        break;
+    }
+    if (isRemote()) {
+        os << "[REMOTE " << this->getEndpoint()->getElementName() << "] ";
+    }
+    if (isSharedConnection()) {
+        os << "[SHARED] ";
+    }
+    os << this->getName();
+    if (indent_lvl == 0) {
+        os << this->getConnectionSummary();
+    }
+    if (incoming_connection) {
+        os << " [" << incoming_connection->getConnPolicy() << "]";
+    }
+    os << std::endl;
 
     for (Connections::const_iterator conn = this->connections_.begin();
          conn != this->connections_.end(); ++conn) {
         if (*((*conn)->to()) == *this) {
-            (*conn)->from()->printIndented(os, depth, indent_lvl + 1, *conn,
+            (*conn)->from()->printIndented(os, indent_lvl + 1, *conn,
                                            printed_connections);
         } else {
-            (*conn)->to()->printIndented(os, depth, indent_lvl + 1, *conn,
+            (*conn)->to()->printIndented(os, indent_lvl + 1, *conn,
                                          printed_connections);
         }
     }
@@ -313,19 +428,24 @@ std::ostream& ConnectionIntrospector::Node::printIndented(
     return os;
 }
 
-std::ostream& operator<<(
-        std::ostream& os,
-        const ConnectionIntrospector& descriptor) {
+std::ostream& ConnectionIntrospector::operator>>(
+        std::ostream& os) const {
 
-    for (ConnectionIntrospector::Nodes::const_iterator node = descriptor.start_nodes_.begin();
-         node != descriptor.start_nodes_.end(); ++node) {
+    for (Nodes::const_iterator node = start_nodes_.begin();
+         node != start_nodes_.end(); ++node) {
+        ConnectionSet printed_connections;
         (*node)->printIndented(
-                    os, descriptor.depth_, 0,
-                    ConnectionIntrospector::ConnectionPtr(),
-                    ConnectionIntrospector::Connections()) << "\n";
+                    os, 0, ConnectionPtr(),
+                    printed_connections) << "\n";
     }
 
     return os;
+}
+
+std::ostream& operator<<(
+        std::ostream& os,
+        const ConnectionIntrospector& introspector) {
+    return introspector >> os;
 }
 
 }  // namespace internal

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -332,7 +332,7 @@ bool ConnectionIntrospector::findOrCreateNeighbor(
     }
     node->connections_.push_back(connection);
 
-    return found;
+    return (found != 0);
 }
 
 ConnectionIntrospector::NodePtr ConnectionIntrospector::findNode(const Node &node) const {

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -29,8 +29,9 @@ namespace internal {
     bool ConnectionIntrospector::PortQualifier::operator==(
             const PortQualifier& other) const {
         // For simplicity, remote ports are always different for now.
-        return !this->is_remote && this->owner_name == other.owner_name &&
-                this->port_name == other.port_name;
+        return !this->is_remote && !other.is_remote &&
+                (this->owner_name == other.owner_name) &&
+                (this->port_name == other.port_name);
     }
 
     bool ConnectionIntrospector::PortQualifier::operator<(
@@ -103,7 +104,7 @@ namespace internal {
             std::list<ConnectionIntrospector>& connection_list = node.sub_connections;
             PortQualifier& port = node.is_forward ? node.in_port : node.out_port;
 
-            // Would be undefined for remote ports.
+            // Would be false for remote ports.
             if (!port.is_remote) {
                 std::list<ConnectionManager::ChannelDescriptor>
                         connections = port.port_ptr->getManager()->getConnections();

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -177,10 +177,25 @@ namespace internal {
                << " COMPONENT\n";
         } else if (this->depth == 0) {
             // For depth 0, only log the port.
+            std::string connection_summary;
+            const int connection_nr = this->sub_connections.size();
+            switch (connection_nr) {
+            case 0:
+                connection_summary = "No";
+                break;
+            case 1:
+                connection_summary = "Single";
+                break;
+            default:
+                connection_summary = "Multiple";
+                break;
+            }
             os << std::string(currIndent, ' ')
                << (this->is_forward ? " IN " : " OUT ")
                << (this->is_forward ? this->in_port
-                                         : this->out_port) << ":\n";
+                                         : this->out_port)
+               << " with " << connection_summary << " connection(s) (#"
+               << connection_nr << ")" << ":\n";
         } else if (this->depth > 0) {
             // Positive depth, log the full connection information.
             os << std::string(currIndent, ' ')

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -158,6 +158,7 @@ void ConnectionIntrospector::reset() {
 }
 
 void ConnectionIntrospector::createGraph(int depth) {
+    depth_ = depth;
     createGraphInternal(depth, start_nodes_);
 }
 
@@ -241,9 +242,87 @@ ConnectionIntrospector::ConnectionPtr ConnectionIntrospector::findConnectionTo(c
     return ConnectionPtr();
 }
 
+std::string ConnectionIntrospector::Node::getConnectionSummary() const {
+    std::string connection_summary;
+    const int connection_nr = this->connections_.size();
+    switch (connection_nr) {
+    case 0:
+        connection_summary = "no";
+        break;
+    case 1:
+        connection_summary = "single";
+        break;
+    default:
+        connection_summary = "multiple";
+        break;
+    }
+
+    return (" with " + connection_summary + " connection(s) (#"
+            + std::to_string(connection_nr) + ")");
+}
+
+std::ostream& ConnectionIntrospector::Node::printIndented(
+        std::ostream& os, int depth, int indent_lvl,
+        const ConnectionPtr incoming_connection,
+        Connections printed_connections) const {
+    if (indent_lvl > depth) return os;
+
+    if (std::find(printed_connections.begin(), printed_connections.end(),
+                  incoming_connection) != printed_connections.end()) {
+        return os;
+    } else if (incoming_connection.get()){
+        printed_connections.push_back(incoming_connection);
+    }
+
+    const std::string port_type = "[" +
+            (this->isPort()
+                ? dynamic_cast<const ConnectionIntrospector::PortNode *>(this)->getPortType()
+                : "NOT")
+            + " port] ";
+    const std::string is_remote =
+            this->isRemote() ? "[REMOTE: " + this->endpoint_->getElementName() + "] "
+                             : "";
+
+    const std::string connection_summary =
+            (indent_lvl == 0 ? this->getConnectionSummary() : "");
+
+    ConnectionPtr connection = incoming_connection;
+    std::ostringstream connection_str;
+    if (connection.get()) {
+        assert(connection->from().get());
+        connection_str << " [" << connection->from_.second.get<2>() << "]";
+    }
+
+    const int currIndent = 4 * indent_lvl;
+    os << std::string(currIndent, ' ')
+       << port_type << is_remote << this->getName() << connection_summary
+       << connection_str.str() << "\n";
+
+    for (Connections::const_iterator conn = this->connections_.begin();
+         conn != this->connections_.end(); ++conn) {
+        if (*((*conn)->to()) == *this) {
+            (*conn)->from()->printIndented(os, depth, indent_lvl + 1, *conn,
+                                           printed_connections);
+        } else {
+            (*conn)->to()->printIndented(os, depth, indent_lvl + 1, *conn,
+                                         printed_connections);
+        }
+    }
+
+    return os;
+}
+
 std::ostream& operator<<(
         std::ostream& os,
         const ConnectionIntrospector& descriptor) {
+
+    for (ConnectionIntrospector::Nodes::const_iterator node = descriptor.start_nodes_.begin();
+         node != descriptor.start_nodes_.end(); ++node) {
+        (*node)->printIndented(
+                    os, descriptor.depth_, 0,
+                    ConnectionIntrospector::ConnectionPtr(), {}) << "\n";
+    }
+
     return os;
 }
 

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -79,7 +79,7 @@ namespace internal {
         in_port.owner_name = tc->getName();
         is_forward = true;
         depth = -1;
-        if (tc->ports()) {
+        if (tc->ports() && !(tc->ports()->getPortNames().empty())) {
             DataFlowInterface::PortNames port_names = tc->ports()->getPortNames();
             for (size_t j = 0; j < port_names.size(); ++j) {
                 const std::string& port_name = port_names.at(j);
@@ -87,6 +87,9 @@ namespace internal {
                 ConnectionIntrospector ci(port_ptr);
                 sub_connections.push_back(ci);
             }
+            in_port.is_remote = false;
+        } else {
+            in_port.is_remote = true;
         }
     }
 

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -43,14 +43,20 @@ namespace internal {
 
     ConnectionIntrospector::ConnectionIntrospector(
             const ConnectionManager::ChannelDescriptor& descriptor,
+            const PortQualifier& port,
             bool forward, int curr_depth) {
         is_forward = forward;
         connection_id = descriptor.get<0>();
         connection_policy = descriptor.get<2>();
-        in_port = PortQualifier(
-                    descriptor.get<1>()->getOutputEndPoint()->getPort());
-        out_port = PortQualifier(
-                    descriptor.get<1>()->getInputEndPoint()->getPort());
+        if (is_forward) {
+            in_port = PortQualifier(
+                        descriptor.get<1>()->getOutputEndPoint()->getPort());
+            out_port = port;
+        } else {
+            in_port = port;
+            out_port = PortQualifier(
+                        descriptor.get<1>()->getInputEndPoint()->getPort());
+        }
         depth = curr_depth;
     }
 
@@ -145,7 +151,7 @@ namespace internal {
                      it != connections.end(); ++it) {
                     // Push back one connection, and add the node to the "to_visit" list.
                     ConnectionIntrospector
-                            conn_descriptor(*it, !node.is_forward, curr_depth + 1);
+                            conn_descriptor(*it, port, !node.is_forward, curr_depth + 1);
                     if (visited.count(conn_descriptor)) {
                         continue;
                     }

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -176,8 +176,6 @@ void ConnectionIntrospector::createGraphInternal(int remaining_depth, const Node
             for(ConnectionManager::Connections::const_iterator con_it = connections.begin();
                 con_it != connections.end(); ++con_it) {
                 const ConnectionManager::ChannelDescriptor &descriptor = *con_it;
-//                const ConnID *conn_id = descriptor.get<0>().get();
-//                const base::PortInterface *other_port = conn_id->getPort();
                 const base::PortInterface *other_port = descriptor.get<1>()->getPort();
                 NodePtr other;
                 if (other_port) {
@@ -243,63 +241,9 @@ ConnectionIntrospector::ConnectionPtr ConnectionIntrospector::findConnectionTo(c
     return ConnectionPtr();
 }
 
-//static std::ostream& ConnectionIntrospector::printIndented(std::ostream& os,
-//        int i) const {
-//    const int currIndent = 4 * this->depth + i;
-//    if (this->depth == -1) {
-//        // For depth -1, only log the component name.
-//        os << std::string(i, ' ') << this->in_port.owner_name
-//           << " COMPONENT\n";
-//    } else if (this->depth == 0) {
-//        // For depth 0, only log the port.
-//        std::string connection_summary;
-//        const int connection_nr = this->sub_connections.size();
-//        switch (connection_nr) {
-//        case 0:
-//            connection_summary = "No";
-//            break;
-//        case 1:
-//            connection_summary = "Single";
-//            break;
-//        default:
-//            connection_summary = "Multiple";
-//            break;
-//        }
-//        os << std::string(currIndent, ' ')
-//           << (this->is_forward ? " IN " : " OUT ")
-//           << (this->is_forward ? this->in_port
-//                                     : this->out_port)
-//           << " with " << connection_summary << " connection(s) (#"
-//           << connection_nr << ")" << ":\n";
-//    } else if (this->depth > 0) {
-//        // Positive depth, log the full connection information.
-//        os << std::string(currIndent, ' ')
-//           << (this->is_forward ? " -> IN " : " <- OUT ")
-//           << ((this->is_forward ? this->in_port
-//                                     : this->out_port).is_remote ?
-//                  "(remote) " : "")
-//           << (this->is_forward ? this->in_port
-//                                     : this->out_port)
-//           << " : (" << this->connection_policy << ")\n";
-//    }
-//    for (std::list< ConnectionIntrospector >::const_iterator
-//            it = this->sub_connections.begin();
-//         it != this->sub_connections.end(); ++it) {
-//        os << *it;
-//    }
-//    return os;
-//}
-
-//boost::function<std::ostream&(std::ostream&)>
-//ConnectionIntrospector::indent(int i) const {
-//    return boost::bind(&ConnectionIntrospector::printIndented, this, _1, i);
-//}
-
 std::ostream& operator<<(
         std::ostream& os,
         const ConnectionIntrospector& descriptor) {
-//    return descriptor.indent(0)(os);
-//    return printTo(descriptor.start_nodes_, os);
     return os;
 }
 

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -181,7 +181,7 @@ void ConnectionIntrospector::createGraphInternal(int remaining_depth, const Node
                 if (other_port) {
                     other.reset( new PortNode(other_port) );
                 } else {
-                    other.reset( new Node(descriptor.get<1>().get()) );
+                    other.reset( new Node(descriptor.get<1>().get(), (descriptor.get<0>() ? descriptor.get<0>()->getName() : "")) );
                 }
 
                 // Check if the other node is already known

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -173,7 +173,7 @@ namespace internal {
                 }
             } else {
                 if (node.connection_id) {
-                    port.port_name = node.connection_id->portName();
+                    port.port_name = node.connection_id->getName();
                 }
             }
         }

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -218,10 +218,12 @@ namespace internal {
             // Positive depth, log the full connection information.
             os << std::string(currIndent, ' ')
                << (this->is_forward ? " -> IN " : " <- OUT ")
+               << ((this->is_forward ? this->in_port
+                                         : this->out_port).is_remote ?
+                      "(remote) " : "")
                << (this->is_forward ? this->in_port
                                          : this->out_port)
-               << " : (" << this->connection_id->typeString()
-               << " = " << this->connection_policy << ")\n";
+               << " : (" << this->connection_policy << ")\n";
         }
         for (std::list< ConnectionIntrospector >::const_iterator
                 it = this->sub_connections.begin();

--- a/rtt/internal/ConnectionIntrospector.cpp
+++ b/rtt/internal/ConnectionIntrospector.cpp
@@ -235,7 +235,7 @@ ConnectionIntrospector::NodePtr ConnectionIntrospector::findNode(const Node &nod
     return NodePtr();
 }
 
-ConnectionIntrospector::ConnectionPtr ConnectionIntrospector::findConnectionTo(const Connections &connections, const Node &node) const {
+ConnectionIntrospector::ConnectionPtr ConnectionIntrospector::findConnectionTo(const Connections &connections, const Node &node) {
     Connections::const_iterator it;
     for(it = connections.begin(); it != connections.end(); ++it) {
         if (*((*it)->to()) == node) return *it;

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -39,6 +39,7 @@ public:
 
     ConnectionIntrospector(
             const ConnectionManager::ChannelDescriptor& descriptor,
+            const PortQualifier& port,
             bool forward, int curr_depth);
     ConnectionIntrospector(const base::PortInterface* port);
     ConnectionIntrospector(const TaskContext* tc);

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -65,11 +65,13 @@ private:
         const_iterator begin() const;
         const_iterator end() const;
 
+        std::ostream& printIndented(std::ostream& os, int depth, int indent_lvl, const ConnectionPtr incoming_connection, Connections printed_connections) const;
     protected:
         Node(base::ChannelElementBase *endpoint, const std::string &name = std::string());
         Direction direction_;
 
     private:
+        std::string getConnectionSummary() const;
         friend class ConnectionIntrospector;
         base::ChannelElementBase::shared_ptr endpoint_;
         std::string name_;

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -119,7 +119,7 @@ private:
     void collectStartNodes(const DataFlowInterface *);
     void createGraphInternal(int remaining_depth, const Nodes& to_visit);
     NodePtr findNode(const Node &node) const;
-    ConnectionPtr findConnectionTo(const Connections &connections, const Node &node) const;
+    static ConnectionPtr findConnectionTo(const Connections &connections, const Node &node);
 
     Nodes start_nodes_;
     Nodes nodes_;

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -41,6 +41,7 @@ public:
             const ConnectionManager::ChannelDescriptor& descriptor,
             bool forward, int curr_depth);
     ConnectionIntrospector(const base::PortInterface* port);
+    ConnectionIntrospector(const TaskContext* tc);
 
     bool operator==(const ConnectionIntrospector& other) const;
 

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -28,40 +28,11 @@ public:
         bool is_forward;
         bool is_remote;
 
-        PortQualifier() {}
-        PortQualifier(const base::PortInterface* port)
-                : port_ptr(port), is_remote(false) {
-            // When the port is invalid, we have a remote port.
-            if (!port_ptr) {
-                port_name = "{REMOTE_PORT}";
-                owner_name = "{REMOTE_OWNER}";
-                is_remote = true;
-                return;
-            }
-            port_name = port_ptr->getName();
-            if (port_ptr->getInterface()) {
-                owner_name = port_ptr->getInterface()->getOwner()->getName();
-            } else {
-                owner_name = "{FREE}";
-            }
-            if ( dynamic_cast<const base::InputPortInterface*>(port_ptr) ) {
-                is_forward = false;
-            } else {
-                is_forward = true;
-            }
-        }
+        PortQualifier();
+        PortQualifier(const base::PortInterface* port);
 
-        bool operator==(const PortQualifier& other) const {
-            // For simplicity, remote ports are always different for now.
-            return !this->is_remote && this->owner_name == other.owner_name &&
-                    this->port_name == other.port_name;
-        }
-
-        bool operator<(const PortQualifier& other) const {
-            if (owner_name < other.owner_name) return true;
-            if (owner_name > other.owner_name) return false;
-            return port_name < other.port_name;
-        }
+        bool operator==(const PortQualifier& other) const;
+        bool operator<(const PortQualifier& other) const;
 
         friend std::ostream& operator<<(std::ostream& os, const PortQualifier&);
     };

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -1,3 +1,41 @@
+/***************************************************************************
+  tag: Intermodalics BVBA  Sat Jan 27 00:13:45 CET 2018  ConnectionIntrospector.hpp
+
+                        ConnectionIntrospector.hpp -  description
+                           -------------------
+    begin                : Sat January 27 2018
+    copyright            : (C) 2018 Intermodalics BVBA
+    email                : info@intermodalics.eu
+
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU General Public                   *
+ *   License as published by the Free Software Foundation;                 *
+ *   version 2 of the License.                                             *
+ *                                                                         *
+ *   As a special exception, you may use this file as part of a free       *
+ *   software library without restriction.  Specifically, if other files   *
+ *   instantiate templates or use macros or inline functions from this     *
+ *   file, or you compile this file and link it with other files to        *
+ *   produce an executable, this file does not by itself cause the         *
+ *   resulting executable to be covered by the GNU General Public          *
+ *   License.  This exception does not however invalidate any other        *
+ *   reasons why the executable file might be covered by the GNU General   *
+ *   Public License.                                                       *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public             *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
 #ifndef ORO_CONNECTION_INTROSPECTOR_HPP
 #define ORO_CONNECTION_INTROSPECTOR_HPP
 
@@ -32,6 +70,7 @@ public:
     void reset();
     void createGraph(int depth = 1);
 
+    std::ostream& operator>>(std::ostream& os) const;
     friend std::ostream& operator<<(std::ostream& os,
                                     const ConnectionIntrospector&);
 
@@ -44,19 +83,22 @@ private:
     class Connection;
     typedef boost::shared_ptr<Connection> ConnectionPtr;
     typedef std::list<ConnectionPtr> Connections;
+    typedef std::set<const Connection *> ConnectionSet;
 
     class Node {
     public:
         virtual ~Node();
 
-        base::ChannelElementBase::shared_ptr getEndpoint() const;
         virtual std::string getName() const;
+        virtual const base::PortInterface *getPort() const;
+        virtual base::ChannelElementBase::shared_ptr getEndpoint() const;
 
-        typedef enum { Unspecified, Input, Output, Both } Direction;
+        typedef enum { Unspecified, Input, Output } Direction;
         Direction getDirection() const { return direction_; }
 
         virtual bool isPort() const { return false; }
-        virtual bool isRemote() const { return true; }
+        virtual bool isRemote() const { return false; }
+        virtual bool isSharedConnection() const { return false; }
 
         virtual bool operator==(const Node& other) const;
         virtual bool operator<(const Node& other) const;
@@ -65,15 +107,15 @@ private:
         const_iterator begin() const;
         const_iterator end() const;
 
-        std::ostream& printIndented(std::ostream& os, int depth, int indent_lvl, const ConnectionPtr incoming_connection, Connections printed_connections) const;
     protected:
-        Node(base::ChannelElementBase *endpoint, const std::string &name = std::string());
+        Node(const std::string &name = std::string());
         Direction direction_;
 
     private:
         std::string getConnectionSummary() const;
+        std::ostream& printIndented(std::ostream& os, int indent_lvl, const ConnectionPtr &incoming_connection, ConnectionSet &printed_connections) const;
+
         friend class ConnectionIntrospector;
-        base::ChannelElementBase::shared_ptr endpoint_;
         std::string name_;
         Connections connections_;
     };
@@ -81,9 +123,7 @@ private:
 
     class PortNode : public Node {
     public:
-        const base::PortInterface *getPort() const;
-        std::string getPortType() const;
-
+        const base::PortInterface *getPort() const { return port_; }
         virtual bool isPort() const { return true; }
         virtual bool isRemote() const;
 
@@ -95,37 +135,75 @@ private:
         const base::PortInterface* port_;
     };
 
+    class RemoteNode : public Node {
+    public:
+        virtual base::ChannelElementBase::shared_ptr getEndpoint() const { return endpoint_; }
+        virtual bool isRemote() const { return true; }
+
+    protected:
+        RemoteNode(const base::ChannelElementBase::shared_ptr &endpoint,
+                   Node::Direction direction,
+                   const std::string &name);
+
+    private:
+        friend class ConnectionIntrospector;
+        base::ChannelElementBase::shared_ptr endpoint_;
+    };
+
+    class SharedConnectionNode : public Node {
+    public:
+        virtual base::ChannelElementBase::shared_ptr getEndpoint() const { return shared_connection_; }
+        virtual bool isSharedConnection() const { return true; }
+
+        const SharedConnectionBase::shared_ptr &getSharedConnection() const { return shared_connection_; }
+
+    protected:
+        SharedConnectionNode(const internal::SharedConnectionBase::shared_ptr &shared_connection);
+
+    private:
+        friend class ConnectionIntrospector;
+        SharedConnectionBase::shared_ptr shared_connection_;
+    };
+
     struct Connection {
     public:
         virtual ~Connection();
 
-        NodePtr from() const;
-        NodePtr to() const;
+        NodePtr from() const { return from_.lock(); }
+        NodePtr to() const { return to_.lock(); }
         NodePtr getOutput() const;
         NodePtr getInput() const;
 
         bool isForward() const;
 
+        const ConnPolicy &getConnPolicy() const { return policy_; }
+
     protected:
         Connection(const NodePtr &from, const NodePtr &to,
-                   const ConnectionManager::ChannelDescriptor &from_descriptor);
+                   const ConnPolicy &policy);
 
     private:
         friend class ConnectionIntrospector;
-        typedef std::pair<NodeWPtr, ConnectionManager::ChannelDescriptor> EndpointDescriptor;
-        EndpointDescriptor from_;
-        EndpointDescriptor to_;
+        NodeWPtr from_;
+        NodeWPtr to_;
+        ConnPolicy policy_;
         bool is_forward_;
     };
 
     void collectStartNodes(const DataFlowInterface *);
     void createGraphInternal(int remaining_depth, const Nodes& to_visit);
+
+    bool findOrCreateNeighbor(
+            const NodePtr &node,
+            const base::ChannelElementBase::shared_ptr &endpoint,
+            Node::Direction direction,
+            const std::string &name, const ConnPolicy &policy,
+            NodePtr &other, ConnectionPtr &connection);
     NodePtr findNode(const Node &node) const;
     static ConnectionPtr findConnectionTo(const Connections &connections, const Node &node);
 
     Nodes start_nodes_;
     Nodes nodes_;
-    int depth_;
 };
 
 }  // namespace internal

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -1,13 +1,13 @@
-#ifndef CONNECTIONINTROSPECTOR_HPP
-#define CONNECTIONINTROSPECTOR_HPP
+#ifndef ORO_CONNECTION_INTROSPECTOR_HPP
+#define ORO_CONNECTION_INTROSPECTOR_HPP
 
-#include "ConnID.hpp"
+#include "../rtt-config.h"
+#include "../rtt-fwd.hpp"
+#include "../base/ChannelElementBase.hpp"
 #include "ConnectionManager.hpp"
+
 #include <boost/shared_ptr.hpp>
-#include "../base/InputPortInterface.hpp"
-#include "../base/PortInterface.hpp"
-#include "../DataFlowInterface.hpp"
-#include "../TaskContext.hpp"
+#include <boost/weak_ptr.hpp>
 
 #include <list>
 #include <set>
@@ -18,65 +18,116 @@ namespace RTT
 namespace internal
 {
 
-class ConnectionIntrospector
+class RTT_API ConnectionIntrospector
 {
 public:
-    struct PortQualifier {
-        std::string owner_name;
-        std::string port_name;
-        const base::PortInterface* port_ptr;
-        bool is_forward;
-        bool is_remote;
-
-        PortQualifier();
-        PortQualifier(const base::PortInterface* port);
-
-        bool operator==(const PortQualifier& other) const;
-        bool operator<(const PortQualifier& other) const;
-
-        friend std::ostream& operator<<(std::ostream& os, const PortQualifier&);
-    };
-
-    ConnectionIntrospector(
-            const ConnectionManager::ChannelDescriptor& descriptor,
-            const PortQualifier& port,
-            bool forward, int curr_depth);
     ConnectionIntrospector(const base::PortInterface* port);
+    ConnectionIntrospector(const DataFlowInterface* dfi);
     ConnectionIntrospector(const TaskContext* tc);
 
-    bool operator==(const ConnectionIntrospector& other) const;
+    void add(const base::PortInterface*);
+    void add(const DataFlowInterface*);
+    void add(const TaskContext*);
 
-    bool operator<(const ConnectionIntrospector& other) const;
-
+    void reset();
     void createGraph(int depth = 1);
-
-    boost::function<std::ostream&(std::ostream&)> indent(int i) const;
-
-    std::ostream& printIndented(std::ostream& os, int i) const;
-
-    void createGraph(int depth, std::list<ConnectionIntrospector*>& to_visit,
-        std::set<ConnectionIntrospector>& visited);
-
-//    void createDot(const std::string& file_name);
 
     friend std::ostream& operator<<(std::ostream& os,
                                     const ConnectionIntrospector&);
 
 private:
-    ConnectionIntrospector();
+    class Node;
+    typedef boost::shared_ptr<Node> NodePtr;
+    typedef boost::weak_ptr<Node> NodeWPtr;
+    typedef std::list<NodePtr> Nodes;
 
-    bool is_forward;
-    PortQualifier in_port;
-    PortQualifier out_port;
-    boost::shared_ptr<ConnID> connection_id;  // Can be casted to port if local
-    // std::string connection_name;
-    ConnPolicy connection_policy;
-    int depth;
-    std::list<ConnectionIntrospector> sub_connections;
+    class Connection;
+    typedef boost::shared_ptr<Connection> ConnectionPtr;
+    typedef std::list<ConnectionPtr> Connections;
+
+    class Node {
+    public:
+        virtual ~Node();
+
+        base::ChannelElementBase::shared_ptr getEndpoint() const;
+        virtual std::string getName() const;
+
+        typedef enum { Unspecified, Input, Output, Both } Direction;
+        Direction getDirection() const { return direction_; }
+
+        virtual bool isPort() const { return false; }
+        virtual bool isRemote() const { return true; }
+
+        virtual bool operator==(const Node& other) const;
+        virtual bool operator<(const Node& other) const;
+
+        typedef Connections::const_iterator const_iterator;
+        const_iterator begin() const;
+        const_iterator end() const;
+
+    protected:
+        Node(base::ChannelElementBase *endpoint, const std::string &name = std::string());
+        Direction direction_;
+
+    private:
+        friend class ConnectionIntrospector;
+        base::ChannelElementBase::shared_ptr endpoint_;
+        std::string name_;
+        Connections connections_;
+    };
+    friend class Node;
+
+    class PortNode : public Node {
+    public:
+        const base::PortInterface *getPort() const;
+        std::string getPortType() const;
+
+        virtual bool isPort() const { return true; }
+        virtual bool isRemote() const;
+
+    protected:
+        PortNode(const base::PortInterface* port);
+
+    private:
+        friend class ConnectionIntrospector;
+        const base::PortInterface* port_;
+    };
+
+    struct Connection {
+    public:
+        virtual ~Connection();
+
+        NodePtr from() const;
+        NodePtr to() const;
+        NodePtr getOutput() const;
+        NodePtr getInput() const;
+
+        bool isForward() const;
+
+    protected:
+        Connection(const NodePtr &from, const NodePtr &to,
+                   const ConnectionManager::ChannelDescriptor &from_descriptor);
+
+    private:
+        friend class ConnectionIntrospector;
+        typedef std::pair<NodeWPtr, ConnectionManager::ChannelDescriptor> EndpointDescriptor;
+        EndpointDescriptor from_;
+        EndpointDescriptor to_;
+        bool is_forward_;
+    };
+
+    void collectStartNodes(const DataFlowInterface *);
+    void createGraphInternal(int remaining_depth, const Nodes& to_visit);
+    NodePtr findNode(const Node &node) const;
+    ConnectionPtr findConnectionTo(const Connections &connections, const Node &node) const;
+
+    Nodes start_nodes_;
+    Nodes nodes_;
+    int depth_;
 };
 
 }  // namespace internal
 
 }  // namespace RTT
 
-#endif // CONNECTIONINTROSPECTOR_HPP
+#endif // ORO_CONNECTION_INTROSPECTOR_HPP

--- a/rtt/internal/ConnectionIntrospector.hpp
+++ b/rtt/internal/ConnectionIntrospector.hpp
@@ -1,0 +1,109 @@
+#ifndef CONNECTIONINTROSPECTOR_HPP
+#define CONNECTIONINTROSPECTOR_HPP
+
+#include "ConnID.hpp"
+#include "ConnectionManager.hpp"
+#include <boost/shared_ptr.hpp>
+#include "../base/InputPortInterface.hpp"
+#include "../base/PortInterface.hpp"
+#include "../DataFlowInterface.hpp"
+#include "../TaskContext.hpp"
+
+#include <list>
+#include <set>
+
+namespace RTT
+{
+
+namespace internal
+{
+
+class ConnectionIntrospector
+{
+public:
+    struct PortQualifier {
+        std::string owner_name;
+        std::string port_name;
+        const base::PortInterface* port_ptr;
+        bool is_forward;
+        bool is_remote;
+
+        PortQualifier() {}
+        PortQualifier(const base::PortInterface* port)
+                : port_ptr(port), is_remote(false) {
+            // When the port is invalid, we have a remote port.
+            if (!port_ptr) {
+                port_name = "{REMOTE_PORT}";
+                owner_name = "{REMOTE_OWNER}";
+                is_remote = true;
+                return;
+            }
+            port_name = port_ptr->getName();
+            if (port_ptr->getInterface()) {
+                owner_name = port_ptr->getInterface()->getOwner()->getName();
+            } else {
+                owner_name = "{FREE}";
+            }
+            if ( dynamic_cast<const base::InputPortInterface*>(port_ptr) ) {
+                is_forward = false;
+            } else {
+                is_forward = true;
+            }
+        }
+
+        bool operator==(const PortQualifier& other) const {
+            // For simplicity, remote ports are always different for now.
+            return !this->is_remote && this->owner_name == other.owner_name &&
+                    this->port_name == other.port_name;
+        }
+
+        bool operator<(const PortQualifier& other) const {
+            if (owner_name < other.owner_name) return true;
+            if (owner_name > other.owner_name) return false;
+            return port_name < other.port_name;
+        }
+
+        friend std::ostream& operator<<(std::ostream& os, const PortQualifier&);
+    };
+
+    ConnectionIntrospector(
+            const ConnectionManager::ChannelDescriptor& descriptor,
+            bool forward, int curr_depth);
+    ConnectionIntrospector(const base::PortInterface* port);
+
+    bool operator==(const ConnectionIntrospector& other) const;
+
+    bool operator<(const ConnectionIntrospector& other) const;
+
+    void createGraph(int depth = 1);
+
+    boost::function<std::ostream&(std::ostream&)> indent(int i) const;
+
+    std::ostream& printIndented(std::ostream& os, int i) const;
+
+    void createGraph(int depth, std::list<ConnectionIntrospector*>& to_visit,
+        std::set<ConnectionIntrospector>& visited);
+
+//    void createDot(const std::string& file_name);
+
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const ConnectionIntrospector&);
+
+private:
+    ConnectionIntrospector();
+
+    bool is_forward;
+    PortQualifier in_port;
+    PortQualifier out_port;
+    boost::shared_ptr<ConnID> connection_id;  // Can be casted to port if local
+    // std::string connection_name;
+    ConnPolicy connection_policy;
+    int depth;
+    std::list<ConnectionIntrospector> sub_connections;
+};
+
+}  // namespace internal
+
+}  // namespace RTT
+
+#endif // CONNECTIONINTROSPECTOR_HPP

--- a/rtt/internal/SharedConnection.cpp
+++ b/rtt/internal/SharedConnection.cpp
@@ -63,12 +63,7 @@ ConnID* SharedConnID::clone() const
     return new SharedConnID(this->connection);
 }
 
-std::string SharedConnID::typeString() const
-{
-    return "SharedConnID";
-}
-
-std::string SharedConnID::portName() const
+std::string SharedConnID::getName() const
 {
     return this->connection->getName();
 }

--- a/rtt/internal/SharedConnection.cpp
+++ b/rtt/internal/SharedConnection.cpp
@@ -63,6 +63,16 @@ ConnID* SharedConnID::clone() const
     return new SharedConnID(this->connection);
 }
 
+std::string SharedConnID::typeString() const
+{
+    return "SharedConnID";
+}
+
+std::string SharedConnID::portName() const
+{
+    return this->connection->getName();
+}
+
 #ifdef ORO_HAVE_BOOST_UUID
 static boost::uuids::random_generator uuid_generator;
 #endif

--- a/rtt/internal/SharedConnection.hpp
+++ b/rtt/internal/SharedConnection.hpp
@@ -102,6 +102,9 @@ namespace internal {
         virtual const std::string &getName() const;
 
         virtual const ConnPolicy *getConnPolicy() const;
+
+        virtual base::MultipleInputsChannelElementBase::Inputs getInputs() const = 0;
+        virtual base::MultipleOutputsChannelElementBase::Outputs getOutputs() const = 0;
     };
 
     /**
@@ -213,6 +216,14 @@ namespace internal {
         {
             return mstorage->data_sample();
         }
+
+        virtual base::MultipleInputsChannelElementBase::Inputs getInputs() const {
+            return base::MultipleInputsChannelElement<T>::getInputs();
+        }
+
+        virtual base::MultipleOutputsChannelElementBase::Outputs getOutputs() const {
+            return base::MultipleOutputsChannelElement<T>::getOutputs();
+        }
     };
 
     template <typename T>
@@ -225,6 +236,14 @@ namespace internal {
             : SharedConnectionBase(policy)
         {}
         virtual ~SharedRemoteConnection() {}
+
+        virtual base::MultipleInputsChannelElementBase::Inputs getInputs() const {
+            return base::MultipleInputsChannelElementBase::Inputs();
+        }
+
+        virtual base::MultipleOutputsChannelElementBase::Outputs getOutputs() const {
+            return base::MultipleOutputsChannelElementBase::Outputs();
+        }
     };
 }}
 

--- a/rtt/internal/SharedConnection.hpp
+++ b/rtt/internal/SharedConnection.hpp
@@ -60,8 +60,7 @@ namespace internal {
             : connection(connection) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
-        virtual std::string typeString() const;
-        virtual std::string portName() const;
+        virtual std::string getName() const;
         template <typename T> boost::intrusive_ptr< SharedConnection<T> > getConnection() const
         {
             return boost::static_pointer_cast< SharedConnection<T> >(connection);

--- a/rtt/internal/SharedConnection.hpp
+++ b/rtt/internal/SharedConnection.hpp
@@ -60,6 +60,8 @@ namespace internal {
             : connection(connection) {}
         virtual ConnID* clone() const;
         virtual bool isSameID(ConnID const& id) const;
+        virtual std::string typeString() const;
+        virtual std::string portName() const;
         template <typename T> boost::intrusive_ptr< SharedConnection<T> > getConnection() const
         {
             return boost::static_pointer_cast< SharedConnection<T> >(connection);

--- a/rtt/transports/corba/DataFlowI.cpp
+++ b/rtt/transports/corba/DataFlowI.cpp
@@ -602,7 +602,6 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
 
         // Creates a proxy to the remote input port
         RemoteInputPort port(writer->getTypeInfo(), reader_interface, reader_port, mpoa);
-        port.setInterface( mdf ); // cheating !
         // Connect to proxy.
         ConnPolicy policy2 = toRTT(policy);
         bool result = writer->createConnection(port, policy2);

--- a/rtt/transports/corba/RemoteConnID.cpp
+++ b/rtt/transports/corba/RemoteConnID.cpp
@@ -65,6 +65,10 @@ RTT::internal::ConnID* RemoteConnID::clone() const {
     return new RemoteConnID( this->dataflow.in(), this->name, this->port);
 }
 
+std::string RemoteConnID::getName() const {
+    return this->name;
+}
+
 const base::PortInterface *RemoteConnID::getPort() const {
     return this->port;
 }

--- a/rtt/transports/corba/RemoteConnID.cpp
+++ b/rtt/transports/corba/RemoteConnID.cpp
@@ -48,11 +48,9 @@
 using namespace RTT;
 using namespace RTT::corba;
 
-RemoteConnID::RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name,
-                           base::PortInterface const* port)
+RemoteConnID::RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name)
 : dataflow(CDataFlowInterface::_duplicate(dataflow))
-  , name(name)
-  , port(port) {}
+  , name(name) {}
 
 bool RemoteConnID::isSameID(ConnID const& id) const
         {
@@ -62,13 +60,9 @@ bool RemoteConnID::isSameID(ConnID const& id) const
         }
 
 RTT::internal::ConnID* RemoteConnID::clone() const {
-    return new RemoteConnID( this->dataflow.in(), this->name, this->port);
+    return new RemoteConnID( this->dataflow.in(), this->name);
 }
 
 std::string RemoteConnID::getName() const {
     return this->name;
-}
-
-const base::PortInterface *RemoteConnID::getPort() const {
-    return this->port;
 }

--- a/rtt/transports/corba/RemoteConnID.cpp
+++ b/rtt/transports/corba/RemoteConnID.cpp
@@ -45,11 +45,14 @@
 
 #include "RemoteConnID.hpp"
 
+using namespace RTT;
 using namespace RTT::corba;
 
-RemoteConnID::RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name)
+RemoteConnID::RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name,
+                           base::PortInterface const* port)
 : dataflow(CDataFlowInterface::_duplicate(dataflow))
-  , name(name) {}
+  , name(name)
+  , port(port) {}
 
 bool RemoteConnID::isSameID(ConnID const& id) const
         {
@@ -59,13 +62,9 @@ bool RemoteConnID::isSameID(ConnID const& id) const
         }
 
 RTT::internal::ConnID* RemoteConnID::clone() const {
-    return new RemoteConnID( this->dataflow.in(), this->name);
+    return new RemoteConnID( this->dataflow.in(), this->name, this->port);
 }
 
-std::string RemoteConnID::typeString() const {
-    return "RemoteConnID";
-}
-
-std::string RemoteConnID::portName() const {
-    return name;
+const base::PortInterface *RemoteConnID::getPort() const {
+    return this->port;
 }

--- a/rtt/transports/corba/RemoteConnID.cpp
+++ b/rtt/transports/corba/RemoteConnID.cpp
@@ -61,3 +61,11 @@ bool RemoteConnID::isSameID(ConnID const& id) const
 RTT::internal::ConnID* RemoteConnID::clone() const {
     return new RemoteConnID( this->dataflow.in(), this->name);
 }
+
+std::string RemoteConnID::typeString() const {
+    return "RemoteConnID";
+}
+
+std::string RemoteConnID::portName() const {
+    return name;
+}

--- a/rtt/transports/corba/RemoteConnID.hpp
+++ b/rtt/transports/corba/RemoteConnID.hpp
@@ -61,13 +61,14 @@ namespace RTT
         {
             const CDataFlowInterface_var dataflow;
             const std::string name;
+            const base::PortInterface * const port;
 
-            RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name);
+            RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name,
+                         base::PortInterface const* port = 0);
 
             bool isSameID(ConnID const& id) const;
             ConnID* clone() const;
-            virtual std::string typeString() const;
-            virtual std::string portName() const;
+            virtual const base::PortInterface *getPort() const;
         };
 
     }

--- a/rtt/transports/corba/RemoteConnID.hpp
+++ b/rtt/transports/corba/RemoteConnID.hpp
@@ -66,6 +66,8 @@ namespace RTT
 
             bool isSameID(ConnID const& id) const;
             ConnID* clone() const;
+            virtual std::string typeString() const;
+            virtual std::string portName() const;
         };
 
     }

--- a/rtt/transports/corba/RemoteConnID.hpp
+++ b/rtt/transports/corba/RemoteConnID.hpp
@@ -61,15 +61,12 @@ namespace RTT
         {
             const CDataFlowInterface_var dataflow;
             const std::string name;
-            const base::PortInterface * const port;
 
-            RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name,
-                         base::PortInterface const* port = 0);
+            RemoteConnID(CDataFlowInterface_ptr dataflow, std::string const& name);
 
             bool isSameID(ConnID const& id) const;
             ConnID* clone() const;
             virtual std::string getName() const;
-            virtual const base::PortInterface *getPort() const;
         };
 
     }

--- a/rtt/transports/corba/RemoteConnID.hpp
+++ b/rtt/transports/corba/RemoteConnID.hpp
@@ -68,6 +68,7 @@ namespace RTT
 
             bool isSameID(ConnID const& id) const;
             ConnID* clone() const;
+            virtual std::string getName() const;
             virtual const base::PortInterface *getPort() const;
         };
 

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -85,7 +85,7 @@ PortableServer::POA_ptr RemotePort<BaseClass>::_default_POA()
 
 template<typename BaseClass>
 RTT::internal::ConnID* RemotePort<BaseClass>::getPortID() const
-{ return new RemoteConnID(dataflow, this->getName()); }
+{ return new RemoteConnID(dataflow, this->getName(), this); }
 
 template<typename BaseClass>
 bool RemotePort<BaseClass>::createStream( const RTT::ConnPolicy& policy )

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -85,7 +85,7 @@ PortableServer::POA_ptr RemotePort<BaseClass>::_default_POA()
 
 template<typename BaseClass>
 RTT::internal::ConnID* RemotePort<BaseClass>::getPortID() const
-{ return new RemoteConnID(dataflow, this->getName(), this); }
+{ return new RemoteConnID(dataflow, this->getQualifiedName()); }
 
 template<typename BaseClass>
 bool RemotePort<BaseClass>::createStream( const RTT::ConnPolicy& policy )

--- a/rtt/transports/mqueue/MQSendRecv.cpp
+++ b/rtt/transports/mqueue/MQSendRecv.cpp
@@ -78,11 +78,12 @@ void MQSendRecv::setupStream(base::DataSourceBase::shared_ptr ds, base::PortInte
 
     if (policy.name_id.empty())
     {
-        if (!port->getInterface() || !port->getInterface()->getOwner() || port->getInterface()->getOwner()->getName().empty())
+        std::string qualified_name = port->getQualifiedName();
+        if (qualified_name == port->getName())
             throw std::runtime_error("MQ name_id not set, and the port is either not attached to a task, or said task has no name. Cannot create a reasonably unique MQ name automatically");
 
         std::stringstream name_stream;
-        name_stream << port->getInterface()->getOwner()->getName() << '.' << port->getName() << '.' << this << '@' << getpid();
+        name_stream << qualified_name << '.' << this << '@' << getpid();
         std::string name = name_stream.str();
         boost::algorithm::replace_all(name, "/", "_");
         policy.name_id = "/" + name;


### PR DESCRIPTION
This is a refactored version of Intermodalics/rtt#3.

Features:
- Introduce new component and port object operations `showPortConnections(int depth)` to enumerate connections of all ports of a component or for a single port (to stdout)
- An [equivalent branch in OCL](https://github.com/Intermodalics/ocl/compare/rdt-toolchain-2.9...Intermodalics:rdt-toolchain-2.9-connection-introspection) adds the same operation to the `OCL::DeploymentComponent` that iterates over all deployed components (Intermodalics/ocl#1).
- If `depth` is greater than one, the operations recurse into connected ports up to the specified level. A single connection (identified by a pair of ports) is only listed once per introspected port (breadth-first search).
- For each connection the direction of data flow and the connection policy is indicated.
- Remote ports or streams are tagged with `[REMOTE <type>]`, where `<type>` names the specific channel element type used for the connection (e.g. `CorbaRemoteChannelElement`). Only the name of the remote port is printed, if available, because its not always preserved after a connection has been established. Connection introspection never recurses into remote connections.
- Shared connections (aka RTT v1 connections) are tagged with `[SHARED]`. In this case the connection instance is printed as if it would be a port on its own, but a connection from one port to a shard connection and to another port only counts as a single hop when checking the maximum depth.

What is missing compared to the original PR Intermodalics/rtt#3 is the output of the connection graph as a [dot file](https://en.wikipedia.org/wiki/DOT_(graph_description_language)). If required, this feature or other machine-readable output formats could be readded here.